### PR TITLE
Use NWM reach slope for normal depth boundary condition

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -53,9 +53,10 @@ Frequently Asked Questions
 .. dropdown:: What boundary condition is used?
 
     A normal depth downstream boundary condition is applied for the initial run of
-    all submodels. The slope used is the NWM reach slope from the hydrofabric data.
-    If no slope is available, a default of 0.001 ft/ft is used (defined in
-    ripple1d/consts.py as NORMAL_DEPTH).
+    all submodels. The slope used is the NWM reach slope from the hydrofabric data for
+    the most downstream reach that intersects the submodel's final downstream cross section.
+    If no such reach is found, the current reach's slope is used instead. If no slope is
+    available, a default of 0.001 ft/ft is used (defined in ripple1d/consts.py as DEFAULT_ND_SLOPE).
 
 .. dropdown:: Which plan, geometry, and flow files are used?
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -57,6 +57,8 @@ Frequently Asked Questions
     the most downstream reach that intersects the submodel's final downstream cross section.
     If no such reach is found, the current reach's slope is used instead. If no slope is
     available, a default of 0.001 ft/ft is used (defined in ripple1d/consts.py as DEFAULT_ND_SLOPE).
+    The selected slope is clamped to [MIN_ND_SLOPE, MAX_ND_SLOPE] (currently [1e-6, 0.1] ft/ft,
+    defined in ripple1d/consts.py) to keep the 1D HEC-RAS steady-flow solver numerically stable.
 
 .. dropdown:: Which plan, geometry, and flow files are used?
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -57,8 +57,8 @@ Frequently Asked Questions
     the most downstream reach that intersects the submodel's final downstream cross section.
     If no such reach is found, the current reach's slope is used instead. If no slope is
     available, a default of 0.001 ft/ft is used (defined in ripple1d/consts.py as DEFAULT_ND_SLOPE).
-    The selected slope is clamped to [MIN_ND_SLOPE, MAX_ND_SLOPE] (currently [1e-6, 0.1] ft/ft,
-    defined in ripple1d/consts.py) to keep the 1D HEC-RAS steady-flow solver numerically stable.
+    The selected slope is clamped to [MIN_ND_SLOPE, MAX_ND_SLOPE] (defined in ripple1d/consts.py)
+    to keep the 1D HEC-RAS steady-flow solver numerically stable.
 
 .. dropdown:: Which plan, geometry, and flow files are used?
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -52,9 +52,10 @@ Frequently Asked Questions
 
 .. dropdown:: What boundary condition is used?
 
-    Regardless of source model boundary condition, a downstream boundary condition
-    of 0.001 ft/ft is applied for the initial run of all submodels. The value of 0.001
-    may be updated by manually editing the ripple1d\\consts.py file.
+    A normal depth downstream boundary condition is applied for the initial run of
+    all submodels. The slope used is the NWM reach slope from the hydrofabric data.
+    If no slope is available, a default of 0.001 ft/ft is used (defined in
+    ripple1d/consts.py as NORMAL_DEPTH).
 
 .. dropdown:: Which plan, geometry, and flow files are used?
 

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -16,7 +16,7 @@ from fiona.errors import DriverError
 from shapely import LineString, MultiLineString, Point, Polygon, box, reverse
 from shapely.ops import linemerge, nearest_points, transform
 
-from ripple1d.consts import DEFAULT_ND_SLOPE, METERS_PER_FOOT
+from ripple1d.consts import DEFAULT_ND_SLOPE, MAX_ND_SLOPE, METERS_PER_FOOT, MIN_ND_SLOPE
 from ripple1d.errors import BadConflation
 from ripple1d.utils.ripple_utils import (
     NWMWalker,
@@ -786,6 +786,20 @@ def _ds_xs_geometry(rfc: RasFimConflater, ras_xs_data: dict) -> LineString:
     return matches.geometry.iloc[0]
 
 
+def _clamp_nd_slope(value: float) -> float:
+    """Clamp a normal-depth slope to [MIN_ND_SLOPE, MAX_ND_SLOPE].
+
+    Logs a WARNING when the value is outside the bounds.
+    """
+    clamped = min(max(value, MIN_ND_SLOPE), MAX_ND_SLOPE)
+    if clamped != value:
+        logging.warning(
+            "Clamped ds_slope from %s to %s (bounds [%s, %s])",
+            value, clamped, MIN_ND_SLOPE, MAX_ND_SLOPE,
+        )
+    return clamped
+
+
 def _select_ds_slope_reach(
     candidates: gpd.GeoDataFrame, current_reach_id, tree_dict: dict
 ) -> Optional[pd.Series]:
@@ -823,7 +837,8 @@ def get_ds_boundary_slope(
     """Return the normal-depth slope from the NWM reach intersecting the downstream XS.
 
     Falls back to the current reach's slope, then DEFAULT_ND_SLOPE, when no
-    candidate is found on the downstream path.
+    candidate is found on the downstream path. The returned slope is clamped
+    to [MIN_ND_SLOPE, MAX_ND_SLOPE].
     """
     current_matches = rfc.nwm_reaches[rfc.nwm_reaches["ID"] == reach_id]
     current_reach_row = current_matches.iloc[0] if not current_matches.empty else None
@@ -837,7 +852,11 @@ def get_ds_boundary_slope(
         except (KeyError, TypeError, ValueError):
             pass
 
-    fallback = (current_slope, str(reach_id)) if current_slope is not None else (DEFAULT_ND_SLOPE, None)
+    fallback = (
+        (_clamp_nd_slope(current_slope), str(reach_id))
+        if current_slope is not None
+        else (_clamp_nd_slope(DEFAULT_ND_SLOPE), None)
+    )
 
     try:
         ds_xs_geom = _ds_xs_geometry(rfc, ras_xs_data)
@@ -864,7 +883,7 @@ def get_ds_boundary_slope(
     try:
         slope = float(selected["slope"])
         if np.isfinite(slope):
-            return slope, str(selected["ID"])
+            return _clamp_nd_slope(slope), str(selected["ID"])
     except (KeyError, TypeError, ValueError):
         pass
 

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -16,7 +16,7 @@ from fiona.errors import DriverError
 from shapely import LineString, MultiLineString, Point, Polygon, box, reverse
 from shapely.ops import linemerge, nearest_points, transform
 
-from ripple1d.consts import METERS_PER_FOOT
+from ripple1d.consts import METERS_PER_FOOT, NORMAL_DEPTH
 from ripple1d.errors import BadConflation
 from ripple1d.utils.ripple_utils import (
     NWMWalker,
@@ -439,6 +439,12 @@ class RasFimConflater:
         except:
             logging.warning(f"No to_id data for {reach_id}")
             metadata["network_to_id"] = "-9999"
+
+        try:
+            metadata["ds_slope"] = float(flow_data["slope"])
+        except Exception:
+            logging.warning(f"No slope data for {reach_id}, using default {NORMAL_DEPTH}")
+            metadata["ds_slope"] = NORMAL_DEPTH
 
         if reach_id in self.local_gages.keys():
             gage_id = self.local_gages[reach_id].replace(" ", "")

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -16,7 +16,13 @@ from fiona.errors import DriverError
 from shapely import LineString, MultiLineString, Point, Polygon, box, reverse
 from shapely.ops import linemerge, nearest_points, transform
 
-from ripple1d.consts import DEFAULT_ND_SLOPE, MAX_ND_SLOPE, METERS_PER_FOOT, MIN_ND_SLOPE
+from ripple1d.consts import (
+    DEFAULT_ND_SLOPE,
+    MAX_ND_SLOPE,
+    METERS_PER_FOOT,
+    MIN_ND_SLOPE,
+    ND_SLOPE_SIG_FIGS,
+)
 from ripple1d.errors import BadConflation
 from ripple1d.utils.ripple_utils import (
     NWMWalker,
@@ -837,8 +843,9 @@ def get_ds_boundary_slope(
     """Return the normal-depth slope from the NWM reach intersecting the downstream XS.
 
     Falls back to the current reach's slope, then DEFAULT_ND_SLOPE, when no
-    candidate is found on the downstream path. The returned slope is clamped
-    to [MIN_ND_SLOPE, MAX_ND_SLOPE].
+    candidate is found on the downstream path. Returned slope is the raw
+    hydrofabric value; callers persisting it for the 1D HEC-RAS steady-flow
+    solver must clamp it via `_clamp_nd_slope`.
     """
     current_matches = rfc.nwm_reaches[rfc.nwm_reaches["ID"] == reach_id]
     current_reach_row = current_matches.iloc[0] if not current_matches.empty else None
@@ -852,11 +859,7 @@ def get_ds_boundary_slope(
         except (KeyError, TypeError, ValueError):
             pass
 
-    fallback = (
-        (_clamp_nd_slope(current_slope), str(reach_id))
-        if current_slope is not None
-        else (_clamp_nd_slope(DEFAULT_ND_SLOPE), None)
-    )
+    fallback = (current_slope, str(reach_id)) if current_slope is not None else (DEFAULT_ND_SLOPE, None)
 
     try:
         ds_xs_geom = _ds_xs_geometry(rfc, ras_xs_data)
@@ -883,7 +886,7 @@ def get_ds_boundary_slope(
     try:
         slope = float(selected["slope"])
         if np.isfinite(slope):
-            return _clamp_nd_slope(slope), str(selected["ID"])
+            return slope, str(selected["ID"])
     except (KeyError, TypeError, ValueError):
         pass
 
@@ -921,7 +924,7 @@ def ras_reaches_metadata(rfc: RasFimConflater, candidate_reaches: gpd.GeoDataFra
                 validate_reach_conflation(ras_xs_data, str(reach.ID))
                 metadata = rfc.get_nwm_reach_metadata(reach.ID)
                 ds_slope, ds_slope_source_nwm_id = get_ds_boundary_slope(rfc, reach.ID, ras_xs_data)
-                metadata["ds_slope"] = ds_slope
+                metadata["ds_slope"] = _clamp_nd_slope(float(f"{ds_slope:.{ND_SLOPE_SIG_FIGS}g}"))
                 if ds_slope_source_nwm_id is not None:
                     metadata["ds_slope_source_nwm_id"] = ds_slope_source_nwm_id
                 reach_metadata[reach.ID] = ras_xs_data | metadata

--- a/ripple1d/conflate/rasfim.py
+++ b/ripple1d/conflate/rasfim.py
@@ -5,7 +5,7 @@ import os
 import sqlite3
 import traceback
 from collections import OrderedDict
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import fiona
 import geopandas as gpd
@@ -16,7 +16,7 @@ from fiona.errors import DriverError
 from shapely import LineString, MultiLineString, Point, Polygon, box, reverse
 from shapely.ops import linemerge, nearest_points, transform
 
-from ripple1d.consts import METERS_PER_FOOT, NORMAL_DEPTH
+from ripple1d.consts import DEFAULT_ND_SLOPE, METERS_PER_FOOT
 from ripple1d.errors import BadConflation
 from ripple1d.utils.ripple_utils import (
     NWMWalker,
@@ -178,7 +178,7 @@ class RasFimConflater:
             return dict(cur.fetchall())
 
     def determine_station_order(self, xs_gdf: gpd.GeoDataFrame, reach: LineString):
-        """Detemine the order based on stationing of the cross sections along the reach."""
+        """Determine the order based on stationing of the cross sections along the reach."""
         rs = []
         for _, xs in xs_gdf.iterrows():
             geom = reach.intersection(xs.geometry)
@@ -440,12 +440,6 @@ class RasFimConflater:
             logging.warning(f"No to_id data for {reach_id}")
             metadata["network_to_id"] = "-9999"
 
-        try:
-            metadata["ds_slope"] = float(flow_data["slope"])
-        except Exception:
-            logging.warning(f"No slope data for {reach_id}, using default {NORMAL_DEPTH}")
-            metadata["ds_slope"] = NORMAL_DEPTH
-
         if reach_id in self.local_gages.keys():
             gage_id = self.local_gages[reach_id].replace(" ", "")
             metadata["gage"] = gage_id
@@ -564,7 +558,7 @@ def ras_xs_geometry_data(rfc: RasFimConflater, xs_id: str) -> dict:
 
 
 def get_us_most_xs_from_junction(rfc, us_river, us_reach):
-    """Search for river reaches at junctions and return xs closest ds reach at junciton."""
+    """Search for river reaches at junctions and return xs closest ds reach at junction."""
     if rfc.ras_junctions is None:
         raise ValueError("No junctions found in the HEC-RAS model.")
     ds_rivers, ds_reaches = None, None
@@ -652,14 +646,14 @@ def map_reach_xs(rfc: RasFimConflater, reach: gpd.GeoSeries) -> dict:
     # find most us and ds xs making sure that they are hydrologicaly connected.
     us_xs, ds_xs = retrieve_us_ds_xs(rfc, intersected_xs, reach)
 
-    # detemine if us end of the nwm reach is between two cross sections. If so grab the upstream cross section (only if stream order=1)
+    # determine if us end of the nwm reach is between two cross sections. If so grab the upstream cross section (only if stream order=1)
     if reach.stream_order == 1 and reach.ID not in rfc.nwm_reaches["to_id"].values:
         us_xs = check_for_us_xs(us_xs, rfc.ras_xs)
 
     # Initialize us_xs data with min /max elevation, then build the dict with added info
     us_data = ras_xs_geometry_data(rfc, us_xs)
 
-    # get infor for the current ds_xs
+    # get info for the current ds_xs
     ras_river = rfc.ras_xs.loc[rfc.ras_xs["river_reach_rs"] == ds_xs, "river"].iloc[0]
     ras_reach = rfc.ras_xs.loc[rfc.ras_xs["river_reach_rs"] == ds_xs, "reach"].iloc[0]
     river_station = rfc.ras_xs.loc[rfc.ras_xs["river_reach_rs"] == ds_xs, "river_station"].iloc[0]
@@ -778,6 +772,109 @@ def retrieve_us_ds_xs(rfc: RasFimConflater, intersected_xs: gpd.GeoDataFrame, re
     return us_xs, ds_xs
 
 
+def _ds_xs_geometry(rfc: RasFimConflater, ras_xs_data: dict) -> LineString:
+    """Return the geometry for the finalized downstream RAS cross section."""
+    ds_xs = ras_xs_data["ds_xs"]
+    ras_xs = rfc.ras_xs
+    matches = ras_xs[
+        (ras_xs["river"] == ds_xs["river"])
+        & (ras_xs["reach"] == ds_xs["reach"])
+        & (ras_xs["river_station"] == ds_xs["xs_id"])
+    ]
+    if matches.empty:
+        raise KeyError(f"Could not find downstream XS geometry for {ds_xs}")
+    return matches.geometry.iloc[0]
+
+
+def _select_ds_slope_reach(
+    candidates: gpd.GeoDataFrame, current_reach_id, tree_dict: dict
+) -> Optional[pd.Series]:
+    """Select the NWM reach whose slope should define the downstream boundary.
+
+    When the downstream XS intersects multiple NWM reaches, walk downstream
+    from the current reach via the to_id chain and pick the furthest
+    downstream candidate. The current reach is a valid candidate if it
+    intersects the ds_xs.
+    """
+    if len(candidates) == 1:
+        return candidates.iloc[0]
+
+    candidate_ids = set(candidates["ID"])
+    most_downstream = current_reach_id if current_reach_id in candidate_ids else None
+    visited = {current_reach_id}
+    current = current_reach_id
+
+    while current in tree_dict:
+        current = tree_dict[current]
+        if current in visited:
+            break
+        visited.add(current)
+        if current in candidate_ids:
+            most_downstream = current  # last match in walk = furthest downstream
+
+    if most_downstream is None:
+        return None
+    return candidates[candidates["ID"] == most_downstream].iloc[0]
+
+
+def get_ds_boundary_slope(
+    rfc: RasFimConflater, reach_id, ras_xs_data: dict
+) -> Tuple[float, Optional[str]]:
+    """Return the normal-depth slope from the NWM reach intersecting the downstream XS.
+
+    Falls back to the current reach's slope, then DEFAULT_ND_SLOPE, when no
+    candidate is found on the downstream path.
+    """
+    current_matches = rfc.nwm_reaches[rfc.nwm_reaches["ID"] == reach_id]
+    current_reach_row = current_matches.iloc[0] if not current_matches.empty else None
+
+    current_slope = None
+    if current_reach_row is not None:
+        try:
+            s = float(current_reach_row["slope"])
+            if np.isfinite(s):
+                current_slope = s
+        except (KeyError, TypeError, ValueError):
+            pass
+
+    fallback = (current_slope, str(reach_id)) if current_slope is not None else (DEFAULT_ND_SLOPE, None)
+
+    try:
+        ds_xs_geom = _ds_xs_geometry(rfc, ras_xs_data)
+    except (KeyError, TypeError, ValueError) as e:
+        logging.warning(
+            "Could not resolve downstream XS geometry for %s; falling back. Error: %s",
+            reach_id, e,
+        )
+        return fallback
+
+    candidates = rfc.nwm_reaches[rfc.nwm_reaches.intersects(ds_xs_geom)]
+    if candidates.empty:
+        logging.warning("No NWM reach intersects downstream XS for %s; falling back", reach_id)
+        return fallback
+
+    selected = _select_ds_slope_reach(candidates, reach_id, rfc.nwm_walker.tree_dict)
+    if selected is None:
+        logging.warning(
+            "No candidate on downstream path for %s; falling back to current reach slope or default",
+            reach_id,
+        )
+        return fallback
+
+    try:
+        slope = float(selected["slope"])
+        if np.isfinite(slope):
+            return slope, str(selected["ID"])
+    except (KeyError, TypeError, ValueError):
+        pass
+
+    logging.warning(
+        "No valid slope data for downstream boundary reach %s; falling back",
+        selected["ID"],
+    )
+    return fallback
+
+
 def validate_reach_conflation(reach_xs_data: dict, reach_id: str):
     """Raise error for invalid conflation.
 
@@ -803,7 +900,12 @@ def ras_reaches_metadata(rfc: RasFimConflater, candidate_reaches: gpd.GeoDataFra
             ras_xs_data = map_reach_xs(rfc, reach)
             if ras_xs_data is not None:
                 validate_reach_conflation(ras_xs_data, str(reach.ID))
-                reach_metadata[reach.ID] = ras_xs_data | rfc.get_nwm_reach_metadata(reach.ID)
+                metadata = rfc.get_nwm_reach_metadata(reach.ID)
+                ds_slope, ds_slope_source_nwm_id = get_ds_boundary_slope(rfc, reach.ID, ras_xs_data)
+                metadata["ds_slope"] = ds_slope
+                if ds_slope_source_nwm_id is not None:
+                    metadata["ds_slope_source_nwm_id"] = ds_slope_source_nwm_id
+                reach_metadata[reach.ID] = ras_xs_data | metadata
         except Exception as e:
             logging.error(f"network id: {reach.ID} | Error: {e}")
             logging.error(f"network id: {reach.ID} | Traceback: {traceback.format_exc()}")

--- a/ripple1d/consts.py
+++ b/ripple1d/consts.py
@@ -21,6 +21,8 @@ MIN_FLOW = 1  # cfs
 
 DEFAULT_EPSG = 4269
 DEFAULT_ND_SLOPE = 0.001
+MIN_ND_SLOPE = 1e-6  # slope lower bound
+MAX_ND_SLOPE = 0.1  # slope upper bound
 
 STAC_API_URL = "https://stac2.dewberryanalytics.com"
 

--- a/ripple1d/consts.py
+++ b/ripple1d/consts.py
@@ -20,7 +20,7 @@ MINDEPTH = 0.1  # ft
 MIN_FLOW = 1  # cfs
 
 DEFAULT_EPSG = 4269
-NORMAL_DEPTH = 0.001
+DEFAULT_ND_SLOPE = 0.001
 
 STAC_API_URL = "https://stac2.dewberryanalytics.com"
 

--- a/ripple1d/consts.py
+++ b/ripple1d/consts.py
@@ -23,6 +23,7 @@ DEFAULT_EPSG = 4269
 DEFAULT_ND_SLOPE = 0.001
 MIN_ND_SLOPE = 1e-6  # slope lower bound
 MAX_ND_SLOPE = 0.1  # slope upper bound
+ND_SLOPE_SIG_FIGS = 6  # significant figures for ds_slope in conflation JSON
 
 STAC_API_URL = "https://stac2.dewberryanalytics.com"
 

--- a/ripple1d/ops/ras_conflate.py
+++ b/ripple1d/ops/ras_conflate.py
@@ -105,7 +105,7 @@ def conflate_model(
     Notes
     -----
     The spatial extents of HEC-RAS river reaches and National Water model (NWM)
-    reaches are not aligned.  The conflate_model endpoint resolves these
+    reaches are not aligned. The conflate_model endpoint resolves these
     differences by associating HEC-RAS models and model components (e.g.
     cross-sections) with the NWM reaches they overlap.
 
@@ -115,7 +115,7 @@ def conflate_model(
     #. For each HEC-RAS river reach within the source model,
       #. Locate the NWM reaches nearest to the most upstream and most
          downstream cross-sections
-      #. Extract all intermediate NWM reaches by walking   the network from
+      #. Extract all intermediate NWM reaches by walking the network from
          upstream to downstream
     #. For each NWM reach extracted,
       #. Locate the HEC-RAS cross-sections that intersect the reach
@@ -135,7 +135,7 @@ def conflate_model(
 
     Additionally, high and low flows are generated for each reach to bound the
     SRC generated in later steps. The low flow is 0.9 times the high flow
-    threshold listed for the reach in the NWM network.  The high flow is the
+    threshold listed for the reach in the NWM network. The high flow is the
     1.2 times the 100 year flow from the NWM network.
     """
     logging.info("conflate_model starting")

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -10,7 +10,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 
-from ripple1d.consts import DEFAULT_EPSG, MIN_FLOW
+from ripple1d.consts import DEFAULT_EPSG, MIN_FLOW, NORMAL_DEPTH
 from ripple1d.data_model import FlowChangeLocation, NwmReachModel
 from ripple1d.errors import UnitsError
 from ripple1d.ras import RasManager
@@ -59,7 +59,8 @@ def create_model_run_normal_depth(
     stage-discharge rating curve for the HEC-RAS submodel. Analysis flows are
     evenly spaced between the min and max discharge for the reach that were
     established by running conflate_model.  The downstream boundary condition
-    for these runs are set to normal depth with slope of 0.001.
+    for these runs are set to normal depth using the NWM reach slope
+    (falls back to 0.001 if unavailable).
     """
     logging.info(f"create_model_run_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)
@@ -108,6 +109,7 @@ def create_model_run_normal_depth(
             nwm_rm.model_name,
             [fcl],
             [i for i in profile_name_map.keys()],
+            normal_depth=nwm_rm.ripple1d_parameters.get("ds_slope", NORMAL_DEPTH),
             write_depth_grids=False,
             show_ras=show_ras,
             run_ras=True,
@@ -164,8 +166,8 @@ def run_incremental_normal_depth(
     model plan with suffix "_ind".  A set of evenly spaced stages are selected
     between the min and max, and discharge values are estimated with linear
     interpolation. The final set of estimated discharges are then run through
-    the model with a normal depth downstream boundary condition with slope of
-    0.001.
+    the model with a normal depth downstream boundary condition using the NWM
+    reach slope (falls back to 0.001 if unavailable).
     """
     logging.info("run_incremental_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)
@@ -209,6 +211,7 @@ def run_incremental_normal_depth(
         nwm_rm.model_name,
         [fcl],
         [i for i in profile_name_map.keys()],
+        normal_depth=nwm_rm.ripple1d_parameters.get("ds_slope", NORMAL_DEPTH),
         write_depth_grids=write_depth_grids,
         show_ras=show_ras,
         run_ras=True,

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -59,7 +59,7 @@ def create_model_run_normal_depth(
     for these runs are set to normal depth using the NWM reach slope for the
     submodel's final downstream cross section (falls back to DEFAULT_ND_SLOPE if
     unavailable). The conflation step bounds the value to
-    [MIN_ND_SLOPE, MAX_ND_SLOPE] (currently [1e-6, 0.1]).
+    [MIN_ND_SLOPE, MAX_ND_SLOPE].
     """
     logging.info(f"create_model_run_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)
@@ -168,7 +168,7 @@ def run_incremental_normal_depth(
     the model with a normal depth downstream boundary condition using the NWM
     reach slope for the submodel's final downstream cross section (falls back to
     DEFAULT_ND_SLOPE if unavailable). The conflation step bounds the value to
-    [MIN_ND_SLOPE, MAX_ND_SLOPE] (currently [1e-6, 0.1]).
+    [MIN_ND_SLOPE, MAX_ND_SLOPE].
     """
     logging.info("run_incremental_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -2,15 +2,12 @@
 
 import json
 import logging
-import os
 from dataclasses import asdict
-from pathlib import Path
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 
-from ripple1d.consts import DEFAULT_EPSG, MIN_FLOW, NORMAL_DEPTH
+from ripple1d.consts import DEFAULT_EPSG, DEFAULT_ND_SLOPE, MIN_FLOW
 from ripple1d.data_model import FlowChangeLocation, NwmReachModel
 from ripple1d.errors import UnitsError
 from ripple1d.ras import RasManager
@@ -59,8 +56,8 @@ def create_model_run_normal_depth(
     stage-discharge rating curve for the HEC-RAS submodel. Analysis flows are
     evenly spaced between the min and max discharge for the reach that were
     established by running conflate_model.  The downstream boundary condition
-    for these runs are set to normal depth using the NWM reach slope
-    (falls back to 0.001 if unavailable).
+    for these runs are set to normal depth using the NWM reach slope for the
+    submodel's final downstream cross section (falls back to DEFAULT_ND_SLOPE if unavailable).
     """
     logging.info(f"create_model_run_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)
@@ -109,7 +106,7 @@ def create_model_run_normal_depth(
             nwm_rm.model_name,
             [fcl],
             [i for i in profile_name_map.keys()],
-            normal_depth=nwm_rm.ripple1d_parameters.get("ds_slope", NORMAL_DEPTH),
+            normal_depth=nwm_rm.ripple1d_parameters.get("ds_slope", DEFAULT_ND_SLOPE),
             write_depth_grids=False,
             show_ras=show_ras,
             run_ras=True,
@@ -167,7 +164,8 @@ def run_incremental_normal_depth(
     between the min and max, and discharge values are estimated with linear
     interpolation. The final set of estimated discharges are then run through
     the model with a normal depth downstream boundary condition using the NWM
-    reach slope (falls back to 0.001 if unavailable).
+    reach slope for the submodel's final downstream cross section (falls back to
+    DEFAULT_ND_SLOPE if unavailable).
     """
     logging.info("run_incremental_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)
@@ -211,7 +209,7 @@ def run_incremental_normal_depth(
         nwm_rm.model_name,
         [fcl],
         [i for i in profile_name_map.keys()],
-        normal_depth=nwm_rm.ripple1d_parameters.get("ds_slope", NORMAL_DEPTH),
+        normal_depth=nwm_rm.ripple1d_parameters.get("ds_slope", DEFAULT_ND_SLOPE),
         write_depth_grids=write_depth_grids,
         show_ras=show_ras,
         run_ras=True,
@@ -362,7 +360,7 @@ def determine_flow_increments(
     nwm_id: str,
     depth_increment: float = 0.5,
 ) -> tuple[np.array]:
-    """Detemine flow increments corresponding to 0.5 ft depth increments using the rating-curve-run results."""
+    """Determine flow increments corresponding to 0.5 ft depth increments using the rating-curve-run results."""
     flows, depths = [], []
     for plan_name in plan_names:
         rm.plan = rm.plans[plan_name]

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -58,8 +58,7 @@ def create_model_run_normal_depth(
     established by running conflate_model.  The downstream boundary condition
     for these runs are set to normal depth using the NWM reach slope for the
     submodel's final downstream cross section (falls back to DEFAULT_ND_SLOPE if
-    unavailable). The conflation step bounds the value to
-    [MIN_ND_SLOPE, MAX_ND_SLOPE].
+    unavailable). The conflation step bounds the value to [MIN_ND_SLOPE, MAX_ND_SLOPE].
     """
     logging.info(f"create_model_run_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -57,7 +57,9 @@ def create_model_run_normal_depth(
     evenly spaced between the min and max discharge for the reach that were
     established by running conflate_model.  The downstream boundary condition
     for these runs are set to normal depth using the NWM reach slope for the
-    submodel's final downstream cross section (falls back to DEFAULT_ND_SLOPE if unavailable).
+    submodel's final downstream cross section (falls back to DEFAULT_ND_SLOPE if
+    unavailable). The conflation step bounds the value to
+    [MIN_ND_SLOPE, MAX_ND_SLOPE] (currently [1e-6, 0.1]).
     """
     logging.info(f"create_model_run_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)
@@ -165,7 +167,8 @@ def run_incremental_normal_depth(
     interpolation. The final set of estimated discharges are then run through
     the model with a normal depth downstream boundary condition using the NWM
     reach slope for the submodel's final downstream cross section (falls back to
-    DEFAULT_ND_SLOPE if unavailable).
+    DEFAULT_ND_SLOPE if unavailable). The conflation step bounds the value to
+    [MIN_ND_SLOPE, MAX_ND_SLOPE] (currently [1e-6, 0.1]).
     """
     logging.info("run_incremental_normal_depth starting")
     nwm_rm = NwmReachModel(submodel_directory)

--- a/ripple1d/ras.py
+++ b/ripple1d/ras.py
@@ -7,8 +7,6 @@ import os
 import platform
 import re
 import subprocess
-import time
-import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import List
@@ -20,8 +18,8 @@ import pandas as pd
 from pyproj import CRS
 
 from ripple1d.consts import (
+    DEFAULT_ND_SLOPE,
     FLOW_HDF_PATH,
-    NORMAL_DEPTH,
     PROFILE_NAMES_HDF_PATH,
     SHOW_RAS,
     SUPPORTED_LAYERS,
@@ -40,20 +38,14 @@ from ripple1d.errors import (
     NoGeometryFileSpecifiedError,
     NoRiverLayerError,
     PlanTitleAlreadyExistsError,
-    RASComputeTimeoutError,
 )
 
 # ToManyPlansError,
 from ripple1d.rasmap import PLAN, RASMAP_631, TERRAIN
 from ripple1d.utils.dg_utils import get_terrain_exe_path
 from ripple1d.utils.ripple_utils import (
-    assert_no_mesh_error,
-    assert_no_ras_compute_error_message,
-    assert_no_ras_geometry_error,
-    assert_no_store_all_maps_error_message,
     decode,
     replace_line_in_contents,
-    resample_vertices,
     search_contents,
     text_block_from_start_end_str,
 )
@@ -224,9 +216,9 @@ class RasManager:
         geom_title: str,
         flow_change_locations: list[FlowChangeLocation],
         profile_names: list[str],
-        normal_depth: float = NORMAL_DEPTH,
+        normal_depth: float = DEFAULT_ND_SLOPE,
         write_depth_grids: bool = False,
-        show_ras: bool = False,
+        show_ras: bool = SHOW_RAS,
         run_ras: bool = True,
         flow_file_description: str = "",
     ):
@@ -275,7 +267,7 @@ class RasManager:
         reach: str,
         us_river_station: float,
         write_depth_grids: bool = False,
-        show_ras: bool = False,
+        show_ras: bool = SHOW_RAS,
         run_ras: bool = True,
     ):
         """Create a new known water surface elevation run."""
@@ -357,7 +349,7 @@ class RasManager:
     @check_windows
     @check_version_installed("631")
     def write_new_plan_text_file(
-        self, plan_flow_title, geom_title, write_depth_grids: bool = False, show_ras=False, run_ras=True
+        self, plan_flow_title, geom_title, write_depth_grids: bool = False, show_ras=SHOW_RAS, run_ras=True
     ):
         """Write new plan text file decorator."""
         if plan_flow_title in self.plans.keys():
@@ -471,7 +463,7 @@ class RasProject(RasTextFile):
         super().__init__(ras_text_file_path, new_file)
 
         if self.file_extension != ".prj":
-            raise TypeError(f"Project extenstion must be .prj, not {self.file_extension}")
+            raise TypeError(f"Project extension must be .prj, not {self.file_extension}")
 
         self._ras_project_basename = os.path.splitext(os.path.basename(self._ras_text_file_path))[0]
         self._ras_dir = os.path.dirname(self._ras_text_file_path)
@@ -560,7 +552,7 @@ class RasProject(RasTextFile):
         """
         new_contents = self.contents
         if f"{plan_ext}" not in VALID_PLANS:
-            raise TypeError(f"Plan extenstion must be one of .p01-.p99, not {plan_ext}")
+            raise TypeError(f"Plan extension must be one of .p01-.p99, not {plan_ext}")
         else:
             new_contents = replace_line_in_contents(new_contents, "Current Plan", plan_ext.lstrip("."))
 
@@ -577,7 +569,7 @@ class RasPlanText(RasTextFile):
     def __init__(self, ras_text_file_path: str, crs: str = None, new_file: bool = False, units: str = "English"):
         super().__init__(ras_text_file_path, new_file)
         if self.file_extension not in VALID_PLANS:
-            raise TypeError(f"Plan extenstion must be one of .p01-.p99, not {self.file_extension}")
+            raise TypeError(f"Plan extension must be one of .p01-.p99, not {self.file_extension}")
         self.crs = crs
         self.hdf_file = self._ras_text_file_path + ".hdf"
         self.units = units
@@ -645,7 +637,7 @@ class RasPlanText(RasTextFile):
         if "u" in extension:
             return f".{search_contents(self.contents, 'Flow File')}"
         else:
-            raise ValueError(f"Expected an unsteady flow extension (.uxx). Recieved: {extension}")
+            raise ValueError(f"Expected an unsteady flow extension (.uxx). Received: {extension}")
 
     @property
     def plan_steady_extension(self):
@@ -686,12 +678,12 @@ class RasPlanText(RasTextFile):
             new_contents = replace_line_in_contents(new_contents, "Short Identifier", short_id)
 
         if f".{geom_ext}" not in VALID_GEOMS:
-            raise TypeError(f"Geometry extenstion must be one of g01-g99, not {geom_ext}")
+            raise TypeError(f"Geometry extension must be one of g01-g99, not {geom_ext}")
         else:
             new_contents = replace_line_in_contents(new_contents, "Geom File", geom_ext)
 
         if f".{flow_ext}" not in VALID_STEADY_FLOWS:
-            raise TypeError(f"Flow extenstion must be one of f01-f99, not {flow_ext}")
+            raise TypeError(f"Flow extension must be one of f01-f99, not {flow_ext}")
         else:
             new_contents = replace_line_in_contents(new_contents, "Flow File", flow_ext)
 
@@ -724,12 +716,12 @@ class RasPlanText(RasTextFile):
             self.contents.append(f"Short Identifier={short_id}")
 
         if f"{geom.file_extension}" not in VALID_GEOMS:
-            raise TypeError(f"Geometry extenstion must be one of .g01-.g99, not {geom.file_extension}")
+            raise TypeError(f"Geometry extension must be one of .g01-.g99, not {geom.file_extension}")
         else:
             self.contents.append(f"Geom File={geom.file_extension.lstrip('.')}")
 
         if f"{flow.file_extension}" not in VALID_STEADY_FLOWS:
-            raise TypeError(f"Flow extenstion must be one of .f01-.f99, not {flow.file_extension}")
+            raise TypeError(f"Flow extension must be one of .f01-.f99, not {flow.file_extension}")
         else:
             self.contents.append(f"Flow File={flow.file_extension.lstrip('.')}")
         if run_rasmapper:
@@ -785,7 +777,7 @@ class RasGeomText(RasTextFile):
     def __init__(self, ras_text_file_path: str, crs: str = None, new_file=False, units: str = "English"):
         super().__init__(ras_text_file_path, new_file)
         if not new_file and self.file_extension not in VALID_GEOMS:
-            raise TypeError(f"Geometry extenstion must be one of .g01-.g99, not {self.file_extension}")
+            raise TypeError(f"Geometry extension must be one of .g01-.g99, not {self.file_extension}")
 
         self.crs = CRS(crs)
         self.units = units
@@ -1148,7 +1140,7 @@ class RasFlowText(RasTextFile):
             raise NotImplementedError("only steady flow (.f**) supported")
 
         if self.file_extension not in VALID_STEADY_FLOWS:
-            raise TypeError(f"Flow extenstion must be one of .f01-.f99, not {self.file_extension}")
+            raise TypeError(f"Flow extension must be one of .f01-.f99, not {self.file_extension}")
 
     def __repr__(self):
         """Representation of the RasFlowText class."""
@@ -1315,7 +1307,7 @@ class RasUnsteadyText(RasTextFile):
             raise NotImplementedError("only steady flow (.u**) supported")
 
         if self.file_extension not in VALID_UNSTEADY_FLOWS:
-            raise TypeError(f"Flow extenstion must be one of .u01-.u99, not {self.file_extension}")
+            raise TypeError(f"Flow extension must be one of .u01-.u99, not {self.file_extension}")
 
     def __repr__(self):
         """Representation of the RasUnsteadyText class."""
@@ -1345,7 +1337,7 @@ class RasMap:
 
     Attributes
     ----------
-    text_file : Text file repressenting the RAS Mapper file
+    text_file : Text file representing the RAS Mapper file
     contents : a text representation of the files contents
     version : HEC-RAS version for this RAS Mapper file
 

--- a/tests/conflation_test.py
+++ b/tests/conflation_test.py
@@ -1,10 +1,8 @@
-import json
-import logging
 import os
 import unittest
 
 import geopandas as gpd
-import pandas as pd
+import numpy as np
 import pytest
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 
@@ -13,9 +11,10 @@ from ripple1d.conflate.rasfim import (
     cacl_avg_nearest_points,
     count_intersecting_lines,
     endpoints_from_multiline,
+    get_ds_boundary_slope,
     nearest_line_to_point,
 )
-from ripple1d.ops.ras_conflate import conflate_model
+from ripple1d.consts import DEFAULT_ND_SLOPE
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_ITEM_FILE = "ras-data/Baxter.json"
@@ -107,6 +106,77 @@ class TestRasFimConflater(unittest.TestCase):
         nwm_reaches = gpd.GeoDataFrame({"geometry": [LineString([(0, 0), (1, 1)])]}, crs="EPSG:4326")
         count = count_intersecting_lines(ras_xs, nwm_reaches)
         self.assertEqual(count.shape[0], 1)
+
+    def _make_rfc(self, xs_geometry, reach_ids, to_ids, slopes, reach_geometries):
+        nwm_reaches = gpd.GeoDataFrame({
+            "ID": reach_ids, "to_id": to_ids, "slope": slopes,
+            "geometry": reach_geometries,
+        })
+        walker = type("MockWalker", (), {"tree_dict": dict(zip(reach_ids, to_ids))})()
+        return type("TestConflater", (), {
+            "ras_xs": gpd.GeoDataFrame({
+                "river": ["A"], "reach": ["A"], "river_station": [1.0],
+                "geometry": [xs_geometry],
+            }),
+            "nwm_reaches": nwm_reaches,
+            "nwm_walker": walker,
+        })()
+
+    def test_ds_boundary_slope_uses_current_reach_when_ds_xs_intersects_current_reach(self):
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(1, -1), (1, 1)]),
+            reach_ids=[1, 2], to_ids=[2, -9999], slopes=[0.001, 0.005],
+            reach_geometries=[LineString([(0, 0), (2, 0)]), LineString([(2, 0), (4, 0)])],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, 0.001)
+        self.assertEqual(source_id, "1")
+
+    def test_ds_boundary_slope_prefers_downstream_reach_when_ds_xs_intersects_both_reaches(self):
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(2, -1), (2, 1)]),
+            reach_ids=[1, 2], to_ids=[2, -9999], slopes=[0.001, 0.005],
+            reach_geometries=[LineString([(0, 0), (2, 0)]), LineString([(2, 0), (4, 0)])],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, 0.005)
+        self.assertEqual(source_id, "2")
+
+    def test_ds_boundary_slope_falls_back_to_current_reach_when_no_candidate_on_downstream_path(self):
+        # xs intersects reaches 2 and 3, but neither is downstream of current reach 1
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(2, -1), (2, 1)]),
+            reach_ids=[1, 2, 3], to_ids=[-9999, -9999, -9999], slopes=[0.002, 0.005, 0.007],
+            reach_geometries=[
+                LineString([(10, 0), (12, 0)]),  # reach 1: far from xs (current reach)
+                LineString([(0, 0), (2, 0)]),    # reach 2: intersects xs
+                LineString([(2, 0), (4, 0)]),    # reach 3: intersects xs
+            ],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, 0.002)
+        self.assertEqual(source_id, "1")
+
+    def test_ds_boundary_slope_falls_back_to_current_reach_when_no_candidates(self):
+        # xs is far from all reaches, so candidates is empty; current reach has valid slope
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(100, -1), (100, 1)]),
+            reach_ids=[1], to_ids=[-9999], slopes=[0.003],
+            reach_geometries=[LineString([(0, 0), (2, 0)])],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, 0.003)
+        self.assertEqual(source_id, "1")
+
+    def test_ds_boundary_slope_falls_back_to_default_when_no_valid_slope_anywhere(self):
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(1, -1), (1, 1)]),
+            reach_ids=[1], to_ids=[-9999], slopes=[np.nan],
+            reach_geometries=[LineString([(0, 0), (2, 0)])],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, DEFAULT_ND_SLOPE)
+        self.assertIsNone(source_id)
 
 
 # TODO: Update to remove refernce to windows User directory

--- a/tests/conflation_test.py
+++ b/tests/conflation_test.py
@@ -179,28 +179,6 @@ class TestRasFimConflater(unittest.TestCase):
         self.assertEqual(slope, DEFAULT_ND_SLOPE)
         self.assertIsNone(source_id)
 
-    def test_ds_boundary_slope_clamps_selected_reach_slope_below_floor(self):
-        # Selected (downstream) reach has slope 5e-7 < MIN_ND_SLOPE; expect floor
-        rfc = self._make_rfc(
-            xs_geometry=LineString([(2, -1), (2, 1)]),
-            reach_ids=[1, 2], to_ids=[2, -9999], slopes=[0.001, 5e-7],
-            reach_geometries=[LineString([(0, 0), (2, 0)]), LineString([(2, 0), (4, 0)])],
-        )
-        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
-        self.assertEqual(slope, MIN_ND_SLOPE)
-        self.assertEqual(source_id, "2")
-
-    def test_ds_boundary_slope_clamps_selected_reach_slope_above_ceiling(self):
-        # Selected (downstream) reach has slope 0.3 > MAX_ND_SLOPE; expect ceiling
-        rfc = self._make_rfc(
-            xs_geometry=LineString([(2, -1), (2, 1)]),
-            reach_ids=[1, 2], to_ids=[2, -9999], slopes=[0.001, 0.3],
-            reach_geometries=[LineString([(0, 0), (2, 0)]), LineString([(2, 0), (4, 0)])],
-        )
-        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
-        self.assertEqual(slope, MAX_ND_SLOPE)
-        self.assertEqual(source_id, "2")
-
     # _clamp_nd_slope unit tests
     def test_clamp_nd_slope_below_floor_returns_floor(self):
         self.assertEqual(_clamp_nd_slope(5e-7), MIN_ND_SLOPE)

--- a/tests/conflation_test.py
+++ b/tests/conflation_test.py
@@ -8,13 +8,14 @@ from shapely.geometry import LineString, MultiLineString, Point, Polygon
 
 from ripple1d.conflate.rasfim import (
     RasFimConflater,
+    _clamp_nd_slope,
     cacl_avg_nearest_points,
     count_intersecting_lines,
     endpoints_from_multiline,
     get_ds_boundary_slope,
     nearest_line_to_point,
 )
-from ripple1d.consts import DEFAULT_ND_SLOPE
+from ripple1d.consts import DEFAULT_ND_SLOPE, MAX_ND_SLOPE, MIN_ND_SLOPE
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_ITEM_FILE = "ras-data/Baxter.json"
@@ -177,6 +178,46 @@ class TestRasFimConflater(unittest.TestCase):
         slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
         self.assertEqual(slope, DEFAULT_ND_SLOPE)
         self.assertIsNone(source_id)
+
+    def test_ds_boundary_slope_clamps_selected_reach_slope_below_floor(self):
+        # Selected (downstream) reach has slope 5e-7 < MIN_ND_SLOPE; expect floor
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(2, -1), (2, 1)]),
+            reach_ids=[1, 2], to_ids=[2, -9999], slopes=[0.001, 5e-7],
+            reach_geometries=[LineString([(0, 0), (2, 0)]), LineString([(2, 0), (4, 0)])],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, MIN_ND_SLOPE)
+        self.assertEqual(source_id, "2")
+
+    def test_ds_boundary_slope_clamps_selected_reach_slope_above_ceiling(self):
+        # Selected (downstream) reach has slope 0.3 > MAX_ND_SLOPE; expect ceiling
+        rfc = self._make_rfc(
+            xs_geometry=LineString([(2, -1), (2, 1)]),
+            reach_ids=[1, 2], to_ids=[2, -9999], slopes=[0.001, 0.3],
+            reach_geometries=[LineString([(0, 0), (2, 0)]), LineString([(2, 0), (4, 0)])],
+        )
+        slope, source_id = get_ds_boundary_slope(rfc, 1, {"ds_xs": {"river": "A", "reach": "A", "xs_id": 1}})
+        self.assertEqual(slope, MAX_ND_SLOPE)
+        self.assertEqual(source_id, "2")
+
+    # _clamp_nd_slope unit tests
+    def test_clamp_nd_slope_below_floor_returns_floor(self):
+        self.assertEqual(_clamp_nd_slope(5e-7), MIN_ND_SLOPE)
+
+    def test_clamp_nd_slope_above_ceiling_returns_ceiling(self):
+        self.assertEqual(_clamp_nd_slope(0.3), MAX_ND_SLOPE)
+
+    def test_clamp_nd_slope_at_exact_floor_unchanged(self):
+        self.assertEqual(_clamp_nd_slope(MIN_ND_SLOPE), MIN_ND_SLOPE)
+
+    def test_clamp_nd_slope_at_exact_ceiling_unchanged(self):
+        self.assertEqual(_clamp_nd_slope(MAX_ND_SLOPE), MAX_ND_SLOPE)
+
+    def test_clamp_nd_slope_within_bounds_unchanged(self):
+        for value in (0.005, DEFAULT_ND_SLOPE, 9.999999747378752e-06):
+            with self.subTest(value=value):
+                self.assertEqual(_clamp_nd_slope(value), value)
 
 
 # TODO: Update to remove refernce to windows User directory

--- a/tests/ras-data/Baxter/Baxter.conflation.json
+++ b/tests/ras-data/Baxter/Baxter.conflation.json
@@ -19,7 +19,7 @@
             "low_flow": 4280,
             "high_flow": 25819,
             "network_to_id": "2820026",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2821866",
             "metrics": {
                 "xs": {
@@ -76,7 +76,7 @@
             "low_flow": 4280,
             "high_flow": 25824,
             "network_to_id": "2821866",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2821866",
             "metrics": {
                 "xs": {
@@ -138,7 +138,7 @@
             "low_flow": 4280,
             "high_flow": 25832,
             "network_to_id": "2820012",
-            "ds_slope": 0.00046999999904073775,
+            "ds_slope": 0.00047,
             "ds_slope_source_nwm_id": "2820012",
             "metrics": {
                 "xs": {
@@ -202,7 +202,7 @@
             "network_to_id": "2820002",
             "gage": "11290000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=11290000&legacy=1",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2820002",
             "metrics": {
                 "xs": {
@@ -264,7 +264,7 @@
             "low_flow": 4280,
             "high_flow": 25831,
             "network_to_id": "2820006",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2820006",
             "metrics": {
                 "xs": {
@@ -326,7 +326,7 @@
             "low_flow": 412,
             "high_flow": 11271,
             "network_to_id": "2823972",
-            "ds_slope": 0.0008099999977275729,
+            "ds_slope": 0.00081,
             "ds_slope_source_nwm_id": "2823972",
             "metrics": {
                 "xs": {
@@ -388,7 +388,7 @@
             "low_flow": 4251,
             "high_flow": 23506,
             "network_to_id": "2823932",
-            "ds_slope": 0.0013099999632686377,
+            "ds_slope": 0.00131,
             "ds_slope_source_nwm_id": "2823932",
             "metrics": {
                 "xs": {
@@ -450,7 +450,7 @@
             "low_flow": 4252,
             "high_flow": 23506,
             "network_to_id": "2826230",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2826230",
             "metrics": {
                 "xs": {
@@ -512,7 +512,7 @@
             "low_flow": 4271,
             "high_flow": 23529,
             "network_to_id": "2823972",
-            "ds_slope": 0.0008099999977275729,
+            "ds_slope": 0.00081,
             "ds_slope_source_nwm_id": "2823972",
             "metrics": {
                 "xs": {
@@ -574,7 +574,7 @@
             "low_flow": 4253,
             "high_flow": 23506,
             "network_to_id": "2823934",
-            "ds_slope": 0.0013800000306218863,
+            "ds_slope": 0.00138,
             "ds_slope_source_nwm_id": "2823934",
             "metrics": {
                 "xs": {
@@ -636,7 +636,7 @@
             "low_flow": 4254,
             "high_flow": 23506,
             "network_to_id": "2826224",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2826224",
             "metrics": {
                 "xs": {
@@ -698,7 +698,7 @@
             "low_flow": 4255,
             "high_flow": 23506,
             "network_to_id": "2823960",
-            "ds_slope": 0.0002899999963119626,
+            "ds_slope": 0.00029,
             "ds_slope_source_nwm_id": "2823960",
             "metrics": {
                 "xs": {

--- a/tests/ras-data/Baxter/Baxter.conflation.json
+++ b/tests/ras-data/Baxter/Baxter.conflation.json
@@ -20,6 +20,7 @@
             "high_flow": 25819,
             "network_to_id": "2820026",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2821866",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -75,7 +76,8 @@
             "low_flow": 4280,
             "high_flow": 25824,
             "network_to_id": "2821866",
-            "ds_slope": 0.00046999999904073775,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2821866",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -136,7 +138,8 @@
             "low_flow": 4280,
             "high_flow": 25832,
             "network_to_id": "2820012",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00046999999904073775,
+            "ds_slope_source_nwm_id": "2820012",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -197,9 +200,10 @@
             "low_flow": 4297,
             "high_flow": 26562,
             "network_to_id": "2820002",
-            "ds_slope": 0.0008099999977275729,
             "gage": "11290000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=11290000&legacy=1",
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2820002",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -261,6 +265,7 @@
             "high_flow": 25831,
             "network_to_id": "2820006",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2820006",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -322,6 +327,7 @@
             "high_flow": 11271,
             "network_to_id": "2823972",
             "ds_slope": 0.0008099999977275729,
+            "ds_slope_source_nwm_id": "2823972",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -382,7 +388,8 @@
             "low_flow": 4251,
             "high_flow": 23506,
             "network_to_id": "2823932",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0013099999632686377,
+            "ds_slope_source_nwm_id": "2823932",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -443,7 +450,8 @@
             "low_flow": 4252,
             "high_flow": 23506,
             "network_to_id": "2826230",
-            "ds_slope": 0.0013099999632686377,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2826230",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -504,7 +512,8 @@
             "low_flow": 4271,
             "high_flow": 23529,
             "network_to_id": "2823972",
-            "ds_slope": 0.0002899999963119626,
+            "ds_slope": 0.0008099999977275729,
+            "ds_slope_source_nwm_id": "2823972",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -565,7 +574,8 @@
             "low_flow": 4253,
             "high_flow": 23506,
             "network_to_id": "2823934",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0013800000306218863,
+            "ds_slope_source_nwm_id": "2823934",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -626,7 +636,8 @@
             "low_flow": 4254,
             "high_flow": 23506,
             "network_to_id": "2826224",
-            "ds_slope": 0.0013800000306218863,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2826224",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -687,7 +698,8 @@
             "low_flow": 4255,
             "high_flow": 23506,
             "network_to_id": "2823960",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0002899999963119626,
+            "ds_slope_source_nwm_id": "2823960",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -734,7 +746,7 @@
         "source_network": {
             "file_name": "flows.parquet",
             "type": "nwm_hydrofabric",
-            "version": "1.1.2"
+            "version": "2.1"
         },
         "conflation_ripple1d_version": "0.10.4",
         "metrics_ripple1d_version": "0.10.4",

--- a/tests/ras-data/Baxter/Baxter.conflation.json
+++ b/tests/ras-data/Baxter/Baxter.conflation.json
@@ -1,425 +1,5 @@
 {
     "reaches": {
-        "2826228": {
-            "us_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 33.4,
-                "max_elevation": 125.0,
-                "xs_id": 84816.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 55.0,
-                "max_elevation": 120.02,
-                "xs_id": 84000.0
-            },
-            "eclipsed": false,
-            "low_flow": 5668,
-            "high_flow": 19588,
-            "network_to_id": "2823932",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 14,
-                        "std": 7,
-                        "min": 9,
-                        "25%": 11,
-                        "50%": 14,
-                        "75%": 16,
-                        "max": 19
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 13,
-                        "std": 10,
-                        "min": 6,
-                        "25%": 10,
-                        "50%": 13,
-                        "75%": 17,
-                        "max": 21
-                    }
-                },
-                "lengths": {
-                    "ras": 821,
-                    "network": 838,
-                    "network_to_ras_ratio": 1.02
-                },
-                "coverage": {
-                    "start": 0.74,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2823932",
-                    "overlap": 272
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "2823932": {
-            "us_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 55.0,
-                "max_elevation": 120.02,
-                "xs_id": 84000.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 35.1,
-                "max_elevation": 120.06,
-                "xs_id": 81920.0
-            },
-            "eclipsed": false,
-            "low_flow": 5669,
-            "high_flow": 19588,
-            "network_to_id": "2826230",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 9,
-                        "std": 6,
-                        "min": 4,
-                        "25%": 5,
-                        "50%": 8,
-                        "75%": 12,
-                        "max": 19
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 23,
-                        "std": 15,
-                        "min": 7,
-                        "25%": 12,
-                        "50%": 20,
-                        "75%": 30,
-                        "max": 47
-                    }
-                },
-                "lengths": {
-                    "ras": 2079,
-                    "network": 2036,
-                    "network_to_ras_ratio": 0.98
-                },
-                "coverage": {
-                    "start": 0.15,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2826230",
-                    "overlap": 431
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "2823960": {
-            "us_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 50.0,
-                "max_elevation": 105.42,
-                "xs_id": 78658.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Lower Reach",
-                "min_elevation": 33.59,
-                "max_elevation": 85.84,
-                "xs_id": 47694.0
-            },
-            "eclipsed": false,
-            "low_flow": 5694,
-            "high_flow": 19607,
-            "network_to_id": "2823972",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 51,
-                        "mean": 23,
-                        "std": 14,
-                        "min": 1,
-                        "25%": 12,
-                        "50%": 20,
-                        "75%": 32,
-                        "max": 53
-                    },
-                    "thalweg_offset": {
-                        "count": 51,
-                        "mean": 27,
-                        "std": 19,
-                        "min": 0,
-                        "25%": 11,
-                        "50%": 23,
-                        "75%": 40,
-                        "max": 71
-                    }
-                },
-                "lengths": {
-                    "ras": 30814,
-                    "network": 30535,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.01,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2823972",
-                    "overlap": 595
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "2826230": {
-            "us_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 35.1,
-                "max_elevation": 120.06,
-                "xs_id": 81920.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 55.0,
-                "max_elevation": 110.29,
-                "xs_id": 80916.0
-            },
-            "eclipsed": false,
-            "low_flow": 5671,
-            "high_flow": 19588,
-            "network_to_id": "2823934",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 17,
-                        "std": 9,
-                        "min": 7,
-                        "25%": 11,
-                        "50%": 17,
-                        "75%": 23,
-                        "max": 29
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 39,
-                        "std": 22,
-                        "min": 6,
-                        "25%": 37,
-                        "50%": 49,
-                        "75%": 52,
-                        "max": 54
-                    }
-                },
-                "lengths": {
-                    "ras": 999,
-                    "network": 909,
-                    "network_to_ras_ratio": 0.91
-                },
-                "coverage": {
-                    "start": 0.38,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2823934",
-                    "overlap": 218
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "2823934": {
-            "us_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 55.0,
-                "max_elevation": 110.29,
-                "xs_id": 80916.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 50.0,
-                "max_elevation": 110.0,
-                "xs_id": 79577.0
-            },
-            "eclipsed": false,
-            "low_flow": 5672,
-            "high_flow": 19589,
-            "network_to_id": "2826224",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 21,
-                        "std": 10,
-                        "min": 6,
-                        "25%": 18,
-                        "50%": 24,
-                        "75%": 27,
-                        "max": 29
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 53,
-                        "std": 2,
-                        "min": 51,
-                        "25%": 52,
-                        "50%": 53,
-                        "75%": 53,
-                        "max": 55
-                    }
-                },
-                "lengths": {
-                    "ras": 1345,
-                    "network": 1304,
-                    "network_to_ras_ratio": 0.97
-                },
-                "coverage": {
-                    "start": 0.17,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2826224",
-                    "overlap": 260
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "2826224": {
-            "us_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 50.0,
-                "max_elevation": 110.0,
-                "xs_id": 79577.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Upper Reach",
-                "min_elevation": 50.0,
-                "max_elevation": 105.42,
-                "xs_id": 78658.0
-            },
-            "eclipsed": false,
-            "low_flow": 5673,
-            "high_flow": 19588,
-            "network_to_id": "2823960",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 13,
-                        "std": 9,
-                        "min": 6,
-                        "25%": 8,
-                        "50%": 10,
-                        "75%": 17,
-                        "max": 23
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 42,
-                        "std": 12,
-                        "min": 30,
-                        "25%": 37,
-                        "50%": 45,
-                        "75%": 49,
-                        "max": 53
-                    }
-                },
-                "lengths": {
-                    "ras": 911,
-                    "network": 993,
-                    "network_to_ras_ratio": 1.09
-                },
-                "coverage": {
-                    "start": 0.3,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2823960",
-                    "overlap": 374
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "2823920": {
-            "us_xs": {
-                "river": "Tule Creek",
-                "reach": "Tributary",
-                "min_elevation": 38.0,
-                "max_elevation": 95.84,
-                "xs_id": 10982.0
-            },
-            "ds_xs": {
-                "river": "Baxter River",
-                "reach": "Lower Reach",
-                "min_elevation": 33.59,
-                "max_elevation": 85.84,
-                "xs_id": 47694.0
-            },
-            "eclipsed": false,
-            "low_flow": 550,
-            "high_flow": 9392,
-            "network_to_id": "2823972",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 26,
-                        "mean": 28,
-                        "std": 16,
-                        "min": 2,
-                        "25%": 16,
-                        "50%": 28,
-                        "75%": 41,
-                        "max": 52
-                    },
-                    "thalweg_offset": {
-                        "count": 26,
-                        "mean": 31,
-                        "std": 17,
-                        "min": 3,
-                        "25%": 17,
-                        "50%": 28,
-                        "75%": 47,
-                        "max": 54
-                    }
-                },
-                "lengths": {
-                    "ras": 11459,
-                    "network": 11221,
-                    "network_to_ras_ratio": 0.98
-                },
-                "coverage": {
-                    "start": 0.82,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "2823972",
-                    "overlap": 476
-                }
-            ],
-            "eclipsed_reaches": []
-        },
         "2821866": {
             "us_xs": {
                 "river": "Baxter River",
@@ -436,9 +16,10 @@
                 "xs_id": 1192.0
             },
             "eclipsed": false,
-            "low_flow": 5707,
-            "high_flow": 21516,
+            "low_flow": 4280,
+            "high_flow": 25819,
             "network_to_id": "2820026",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -491,9 +72,10 @@
                 "xs_id": 2877.0
             },
             "eclipsed": false,
-            "low_flow": 5707,
-            "high_flow": 21520,
+            "low_flow": 4280,
+            "high_flow": 25824,
             "network_to_id": "2821866",
+            "ds_slope": 0.00046999999904073775,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -551,9 +133,10 @@
                 "xs_id": 12789.0
             },
             "eclipsed": false,
-            "low_flow": 5707,
-            "high_flow": 21527,
+            "low_flow": 4280,
+            "high_flow": 25832,
             "network_to_id": "2820012",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -611,9 +194,10 @@
                 "xs_id": 38312.0
             },
             "eclipsed": false,
-            "low_flow": 5729,
-            "high_flow": 22135,
+            "low_flow": 4297,
+            "high_flow": 26562,
             "network_to_id": "2820002",
+            "ds_slope": 0.0008099999977275729,
             "gage": "11290000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=11290000&legacy=1",
             "metrics": {
@@ -673,9 +257,10 @@
                 "xs_id": 13617.0
             },
             "eclipsed": false,
-            "low_flow": 5707,
-            "high_flow": 21526,
+            "low_flow": 4280,
+            "high_flow": 25831,
             "network_to_id": "2820006",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -716,21 +301,448 @@
                 }
             ],
             "eclipsed_reaches": []
+        },
+        "2823920": {
+            "us_xs": {
+                "river": "Tule Creek",
+                "reach": "Tributary",
+                "min_elevation": 38.0,
+                "max_elevation": 95.84,
+                "xs_id": 10982.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Lower Reach",
+                "min_elevation": 33.59,
+                "max_elevation": 85.84,
+                "xs_id": 47694.0
+            },
+            "eclipsed": false,
+            "low_flow": 412,
+            "high_flow": 11271,
+            "network_to_id": "2823972",
+            "ds_slope": 0.0008099999977275729,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 26,
+                        "mean": 28,
+                        "std": 16,
+                        "min": 2,
+                        "25%": 16,
+                        "50%": 28,
+                        "75%": 41,
+                        "max": 52
+                    },
+                    "thalweg_offset": {
+                        "count": 26,
+                        "mean": 31,
+                        "std": 17,
+                        "min": 3,
+                        "25%": 17,
+                        "50%": 28,
+                        "75%": 47,
+                        "max": 54
+                    }
+                },
+                "lengths": {
+                    "ras": 11459,
+                    "network": 11221,
+                    "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.82,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2823972",
+                    "overlap": 476
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "2826228": {
+            "us_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 33.4,
+                "max_elevation": 125.0,
+                "xs_id": 84816.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 55.0,
+                "max_elevation": 120.02,
+                "xs_id": 84000.0
+            },
+            "eclipsed": false,
+            "low_flow": 4251,
+            "high_flow": 23506,
+            "network_to_id": "2823932",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 14,
+                        "std": 7,
+                        "min": 9,
+                        "25%": 11,
+                        "50%": 14,
+                        "75%": 16,
+                        "max": 19
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 13,
+                        "std": 10,
+                        "min": 6,
+                        "25%": 10,
+                        "50%": 13,
+                        "75%": 17,
+                        "max": 21
+                    }
+                },
+                "lengths": {
+                    "ras": 821,
+                    "network": 838,
+                    "network_to_ras_ratio": 1.02
+                },
+                "coverage": {
+                    "start": 0.74,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2823932",
+                    "overlap": 272
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "2823932": {
+            "us_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 55.0,
+                "max_elevation": 120.02,
+                "xs_id": 84000.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 35.1,
+                "max_elevation": 120.06,
+                "xs_id": 81920.0
+            },
+            "eclipsed": false,
+            "low_flow": 4252,
+            "high_flow": 23506,
+            "network_to_id": "2826230",
+            "ds_slope": 0.0013099999632686377,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 9,
+                        "std": 6,
+                        "min": 4,
+                        "25%": 5,
+                        "50%": 8,
+                        "75%": 12,
+                        "max": 19
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 23,
+                        "std": 15,
+                        "min": 7,
+                        "25%": 12,
+                        "50%": 20,
+                        "75%": 30,
+                        "max": 47
+                    }
+                },
+                "lengths": {
+                    "ras": 2079,
+                    "network": 2036,
+                    "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.15,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2826230",
+                    "overlap": 431
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "2823960": {
+            "us_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 50.0,
+                "max_elevation": 105.42,
+                "xs_id": 78658.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Lower Reach",
+                "min_elevation": 33.59,
+                "max_elevation": 85.84,
+                "xs_id": 47694.0
+            },
+            "eclipsed": false,
+            "low_flow": 4271,
+            "high_flow": 23529,
+            "network_to_id": "2823972",
+            "ds_slope": 0.0002899999963119626,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 51,
+                        "mean": 23,
+                        "std": 14,
+                        "min": 1,
+                        "25%": 12,
+                        "50%": 20,
+                        "75%": 32,
+                        "max": 53
+                    },
+                    "thalweg_offset": {
+                        "count": 51,
+                        "mean": 27,
+                        "std": 19,
+                        "min": 0,
+                        "25%": 11,
+                        "50%": 23,
+                        "75%": 40,
+                        "max": 71
+                    }
+                },
+                "lengths": {
+                    "ras": 30814,
+                    "network": 30535,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.01,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2823972",
+                    "overlap": 595
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "2826230": {
+            "us_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 35.1,
+                "max_elevation": 120.06,
+                "xs_id": 81920.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 55.0,
+                "max_elevation": 110.29,
+                "xs_id": 80916.0
+            },
+            "eclipsed": false,
+            "low_flow": 4253,
+            "high_flow": 23506,
+            "network_to_id": "2823934",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 17,
+                        "std": 9,
+                        "min": 7,
+                        "25%": 11,
+                        "50%": 17,
+                        "75%": 23,
+                        "max": 29
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 39,
+                        "std": 22,
+                        "min": 6,
+                        "25%": 37,
+                        "50%": 49,
+                        "75%": 52,
+                        "max": 54
+                    }
+                },
+                "lengths": {
+                    "ras": 999,
+                    "network": 909,
+                    "network_to_ras_ratio": 0.91
+                },
+                "coverage": {
+                    "start": 0.38,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2823934",
+                    "overlap": 218
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "2823934": {
+            "us_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 55.0,
+                "max_elevation": 110.29,
+                "xs_id": 80916.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 50.0,
+                "max_elevation": 110.0,
+                "xs_id": 79577.0
+            },
+            "eclipsed": false,
+            "low_flow": 4254,
+            "high_flow": 23506,
+            "network_to_id": "2826224",
+            "ds_slope": 0.0013800000306218863,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 21,
+                        "std": 10,
+                        "min": 6,
+                        "25%": 18,
+                        "50%": 24,
+                        "75%": 27,
+                        "max": 29
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 53,
+                        "std": 2,
+                        "min": 51,
+                        "25%": 52,
+                        "50%": 53,
+                        "75%": 53,
+                        "max": 55
+                    }
+                },
+                "lengths": {
+                    "ras": 1345,
+                    "network": 1304,
+                    "network_to_ras_ratio": 0.97
+                },
+                "coverage": {
+                    "start": 0.17,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2826224",
+                    "overlap": 260
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "2826224": {
+            "us_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 50.0,
+                "max_elevation": 110.0,
+                "xs_id": 79577.0
+            },
+            "ds_xs": {
+                "river": "Baxter River",
+                "reach": "Upper Reach",
+                "min_elevation": 50.0,
+                "max_elevation": 105.42,
+                "xs_id": 78658.0
+            },
+            "eclipsed": false,
+            "low_flow": 4255,
+            "high_flow": 23506,
+            "network_to_id": "2823960",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 13,
+                        "std": 9,
+                        "min": 6,
+                        "25%": 8,
+                        "50%": 10,
+                        "75%": 17,
+                        "max": 23
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 42,
+                        "std": 12,
+                        "min": 30,
+                        "25%": 37,
+                        "50%": 45,
+                        "75%": 49,
+                        "max": 53
+                    }
+                },
+                "lengths": {
+                    "ras": 911,
+                    "network": 993,
+                    "network_to_ras_ratio": 1.09
+                },
+                "coverage": {
+                    "start": 0.3,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "2823960",
+                    "overlap": 374
+                }
+            ],
+            "eclipsed_reaches": []
         }
     },
     "metadata": {
         "source_network": {
             "file_name": "flows.parquet",
-            "version": "2.1",
-            "type": "nwm_hydrofabric"
+            "type": "nwm_hydrofabric",
+            "version": "1.1.2"
         },
-        "conflation_png": "Baxter.conflation.png",
-        "conflation_ripple1d_version": "0.4.2",
-        "metrics_ripple1d_version": "0.4.2",
+        "conflation_ripple1d_version": "0.10.4",
+        "metrics_ripple1d_version": "0.10.4",
         "source_ras_model": {
             "stac_api": "https://stac2.dewberryanalytics.com",
             "stac_collection_id": "ebfe-12090301_LowerColoradoCummins",
             "stac_item_id": "137a9667-e5cf-4cea-b6ec-2e882a42fdc8",
+            "units": "English",
             "source_ras_files": {
                 "geometry": "Baxter.g02",
                 "forcing": "Baxter.f01",

--- a/tests/ras-data/MissFldwy/MissFldwy.conflation.json
+++ b/tests/ras-data/MissFldwy/MissFldwy.conflation.json
@@ -19,7 +19,8 @@
             "low_flow": 313116,
             "high_flow": 2271710,
             "network_to_id": "5096814",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0016899999463930726,
+            "ds_slope_source_nwm_id": "5096814",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -80,7 +81,8 @@
             "low_flow": 313137,
             "high_flow": 2271658,
             "network_to_id": "5092604",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092614",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -143,7 +145,8 @@
             "low_flow": 311964,
             "high_flow": 2262053,
             "network_to_id": "5092598",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope_source_nwm_id": "5092598",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -204,7 +207,8 @@
             "low_flow": 311945,
             "high_flow": 2261930,
             "network_to_id": "5092748",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092748",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -265,7 +269,8 @@
             "low_flow": 311964,
             "high_flow": 2262109,
             "network_to_id": "5092594",
-            "ds_slope": 0.0008099999977275729,
+            "ds_slope": 0.00011999999696854502,
+            "ds_slope_source_nwm_id": "5092594",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -326,7 +331,8 @@
             "low_flow": 311953,
             "high_flow": 2262028,
             "network_to_id": "5092590",
-            "ds_slope": 9.000000136438757e-05,
+            "ds_slope": 0.0008099999977275729,
+            "ds_slope_source_nwm_id": "5092590",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -387,7 +393,8 @@
             "low_flow": 312044,
             "high_flow": 2263096,
             "network_to_id": "5092586",
-            "ds_slope": 2.9999999242136255e-05,
+            "ds_slope": 9.000000136438757e-05,
+            "ds_slope_source_nwm_id": "5092586",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -449,6 +456,7 @@
             "high_flow": 2263113,
             "network_to_id": "5092562",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092562",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -509,7 +517,8 @@
             "low_flow": 312049,
             "high_flow": 2262999,
             "network_to_id": "5092552",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092552",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -570,7 +579,8 @@
             "low_flow": 312055,
             "high_flow": 2263142,
             "network_to_id": "5092542",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 7.999999797903001e-05,
+            "ds_slope_source_nwm_id": "5092542",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -631,7 +641,8 @@
             "low_flow": 312054,
             "high_flow": 2263096,
             "network_to_id": "5090014",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00013000000035390258,
+            "ds_slope_source_nwm_id": "5090014",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -693,6 +704,7 @@
             "high_flow": 2263132,
             "network_to_id": "5090010",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5090010",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -753,7 +765,8 @@
             "low_flow": 312063,
             "high_flow": 2263172,
             "network_to_id": "5090004",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5090004",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -814,7 +827,8 @@
             "low_flow": 312063,
             "high_flow": 2263144,
             "network_to_id": "5090000",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.000539999979082495,
+            "ds_slope_source_nwm_id": "5090000",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -875,7 +889,8 @@
             "low_flow": 311261,
             "high_flow": 2276430,
             "network_to_id": "5089986",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0002500000118743628,
+            "ds_slope_source_nwm_id": "5089986",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -936,7 +951,8 @@
             "low_flow": 311267,
             "high_flow": 2276412,
             "network_to_id": "5089984",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089984",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -997,7 +1013,8 @@
             "low_flow": 313129,
             "high_flow": 2272768,
             "network_to_id": "5092712",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00016999999934341758,
+            "ds_slope_source_nwm_id": "5092712",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1058,7 +1075,8 @@
             "low_flow": 313132,
             "high_flow": 2272717,
             "network_to_id": "5092698",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 0.0001500000071246177,
+            "ds_slope_source_nwm_id": "5092698",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1120,6 +1138,7 @@
             "high_flow": 2273497,
             "network_to_id": "5092646",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092646",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1181,6 +1200,7 @@
             "high_flow": 2273521,
             "network_to_id": "5092634",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092634",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1241,7 +1261,8 @@
             "low_flow": 311298,
             "high_flow": 2277330,
             "network_to_id": "5096766",
-            "ds_slope": 0.00026000000070780516,
+            "ds_slope": 4.999999873689376e-05,
+            "ds_slope_source_nwm_id": "5096766",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1302,7 +1323,8 @@
             "low_flow": 311308,
             "high_flow": 2277306,
             "network_to_id": "5089952",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089952",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1364,6 +1386,7 @@
             "high_flow": 2277231,
             "network_to_id": "5089960",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089970",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1426,7 +1449,8 @@
             "low_flow": 312059,
             "high_flow": 2263257,
             "network_to_id": "5092566",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0002099999983329326,
+            "ds_slope_source_nwm_id": "5092566",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1487,7 +1511,8 @@
             "low_flow": 313362,
             "high_flow": 2273460,
             "network_to_id": "5092616",
-            "ds_slope": 0.0016899999463930726,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092616",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1548,7 +1573,8 @@
             "low_flow": 311960,
             "high_flow": 2262203,
             "network_to_id": "5092602",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 5.999999848427251e-05,
+            "ds_slope_source_nwm_id": "5092606",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1611,7 +1637,8 @@
             "low_flow": 312059,
             "high_flow": 2263257,
             "network_to_id": "5092568",
-            "ds_slope": 0.0002099999983329326,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092568",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1672,7 +1699,8 @@
             "low_flow": 312059,
             "high_flow": 2263204,
             "network_to_id": "5092572",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00014000000373926014,
+            "ds_slope_source_nwm_id": "5092572",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1733,7 +1761,8 @@
             "low_flow": 312048,
             "high_flow": 2263183,
             "network_to_id": "5092582",
-            "ds_slope": 0.00014000000373926014,
+            "ds_slope": 2.9999999242136255e-05,
+            "ds_slope_source_nwm_id": "5092582",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1794,7 +1823,8 @@
             "low_flow": 311263,
             "high_flow": 2276431,
             "network_to_id": "5089990",
-            "ds_slope": 0.0002500000118743628,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089998",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1857,7 +1887,8 @@
             "low_flow": 311296,
             "high_flow": 2277122,
             "network_to_id": "5089978",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope_source_nwm_id": "5089978",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1919,6 +1950,7 @@
             "high_flow": 2277464,
             "network_to_id": "5089932",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089938",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1981,7 +2013,8 @@
             "low_flow": 311295,
             "high_flow": 2277301,
             "network_to_id": "5089946",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00026000000070780516,
+            "ds_slope_source_nwm_id": "5089946",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2042,7 +2075,8 @@
             "low_flow": 313251,
             "high_flow": 2273215,
             "network_to_id": "5092652",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 7.999999797903001e-05,
+            "ds_slope_source_nwm_id": "5092676",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2106,6 +2140,7 @@
             "high_flow": 2273522,
             "network_to_id": "5092626",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092630",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2168,9 +2203,10 @@
             "low_flow": 313362,
             "high_flow": 2273502,
             "network_to_id": "5092622",
-            "ds_slope": 9.999999747378752e-06,
             "gage": "07022000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07022000&legacy=1",
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092622",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2232,6 +2268,7 @@
             "high_flow": 2242929,
             "network_to_id": "5093440",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5093440",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2293,6 +2330,7 @@
             "high_flow": 2242849,
             "network_to_id": "5093450",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5093450",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2353,7 +2391,8 @@
             "low_flow": 313358,
             "high_flow": 2243140,
             "network_to_id": "5092686",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00016999999934341758,
+            "ds_slope_source_nwm_id": "5092686",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2414,7 +2453,8 @@
             "low_flow": 313346,
             "high_flow": 2242953,
             "network_to_id": "5092702",
-            "ds_slope": 7.000000186963007e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092702",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2475,7 +2515,8 @@
             "low_flow": 313356,
             "high_flow": 2243136,
             "network_to_id": "5092696",
-            "ds_slope": 0.00016999999934341758,
+            "ds_slope": 7.000000186963007e-05,
+            "ds_slope_source_nwm_id": "5092696",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2537,6 +2578,7 @@
             "high_flow": 2243004,
             "network_to_id": "5092706",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092706",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2597,7 +2639,8 @@
             "low_flow": 313372,
             "high_flow": 2243130,
             "network_to_id": "5092674",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092674",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2658,7 +2701,8 @@
             "low_flow": 313007,
             "high_flow": 2272449,
             "network_to_id": "5092660",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 7.999999797903001e-05,
+            "ds_slope_source_nwm_id": "5092660",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2720,6 +2764,7 @@
             "high_flow": 2242718,
             "network_to_id": "5093446",
             "ds_slope": 0.00033000000985339284,
+            "ds_slope_source_nwm_id": "5093448",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2775,7 +2820,8 @@
             "low_flow": 313008,
             "high_flow": 2272411,
             "network_to_id": "5092656",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope_source_nwm_id": "5092656",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2836,7 +2882,8 @@
             "low_flow": 313062,
             "high_flow": 2272490,
             "network_to_id": "5092710",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00016999999934341758,
+            "ds_slope_source_nwm_id": "5092704",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2899,7 +2946,8 @@
             "low_flow": 313109,
             "high_flow": 2272707,
             "network_to_id": "5093444",
-            "ds_slope": 0.00016999999934341758,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5093444",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2960,7 +3008,8 @@
             "low_flow": 313045,
             "high_flow": 2272440,
             "network_to_id": "5092684",
-            "ds_slope": 0.00016999999934341758,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092684",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3021,7 +3070,8 @@
             "low_flow": 313038,
             "high_flow": 2272582,
             "network_to_id": "5092658",
-            "ds_slope": 0.0002800000074785203,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5092658",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3082,7 +3132,8 @@
             "low_flow": 313040,
             "high_flow": 2272558,
             "network_to_id": "5092664",
-            "ds_slope": 0.00023999999393709004,
+            "ds_slope": 0.0002800000074785203,
+            "ds_slope_source_nwm_id": "5092664",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3143,7 +3194,8 @@
             "low_flow": 313040,
             "high_flow": 2272524,
             "network_to_id": "5092670",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00023999999393709004,
+            "ds_slope_source_nwm_id": "5092670",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3204,7 +3256,8 @@
             "low_flow": 313307,
             "high_flow": 2242809,
             "network_to_id": "5093448",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00033000000985339284,
+            "ds_slope_source_nwm_id": "5093448",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3266,6 +3319,7 @@
             "high_flow": 2277489,
             "network_to_id": "5089926",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089926",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3326,7 +3380,8 @@
             "low_flow": 311305,
             "high_flow": 2277445,
             "network_to_id": "5089922",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5089922",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3387,7 +3442,8 @@
             "low_flow": 311248,
             "high_flow": 2277381,
             "network_to_id": "5089920",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope_source_nwm_id": "5089920",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3448,7 +3504,8 @@
             "low_flow": 311249,
             "high_flow": 2277484,
             "network_to_id": "5089914",
-            "ds_slope": 0.00011000000085914508,
+            "ds_slope": 0.00013000000035390258,
+            "ds_slope_source_nwm_id": "5089914",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3509,9 +3566,10 @@
             "low_flow": 311293,
             "high_flow": 2277393,
             "network_to_id": "5089912",
-            "ds_slope": 0.00011999999696854502,
             "gage": "07020500",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07020500&legacy=1",
+            "ds_slope": 0.00011000000085914508,
+            "ds_slope_source_nwm_id": "5089912",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3572,7 +3630,8 @@
             "low_flow": 311017,
             "high_flow": 2275401,
             "network_to_id": "5089904",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 0.00011999999696854502,
+            "ds_slope_source_nwm_id": "5089904",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3633,7 +3692,8 @@
             "low_flow": 742,
             "high_flow": 51750,
             "network_to_id": "5089894",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.0007999999797903001,
+            "ds_slope_source_nwm_id": "5089892",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3689,7 +3749,8 @@
             "low_flow": 307951,
             "high_flow": 2273230,
             "network_to_id": "3630829",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0002500000118743628,
+            "ds_slope_source_nwm_id": "3630829",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3750,7 +3811,8 @@
             "low_flow": 307963,
             "high_flow": 2273017,
             "network_to_id": "5090052",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5090052",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3811,7 +3873,8 @@
             "low_flow": 307965,
             "high_flow": 2273343,
             "network_to_id": "3629943",
-            "ds_slope": 0.0002500000118743628,
+            "ds_slope": 0.00013000000035390258,
+            "ds_slope_source_nwm_id": "3629943",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3872,7 +3935,8 @@
             "low_flow": 307966,
             "high_flow": 2273110,
             "network_to_id": "5089872",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0004400000034365803,
+            "ds_slope_source_nwm_id": "5089868",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3935,7 +3999,8 @@
             "low_flow": 311105,
             "high_flow": 2277346,
             "network_to_id": "5089890",
-            "ds_slope": 0.00018000000272877514,
+            "ds_slope": 4.999999873689376e-05,
+            "ds_slope_source_nwm_id": "5089890",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3997,6 +4062,7 @@
             "high_flow": 14237,
             "network_to_id": "5088488",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5088524",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4059,7 +4125,8 @@
             "low_flow": 311106,
             "high_flow": 2277533,
             "network_to_id": "5089870",
-            "ds_slope": 0.0004400000034365803,
+            "ds_slope": 7.999999797903001e-05,
+            "ds_slope_source_nwm_id": "5089880",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4122,7 +4189,8 @@
             "low_flow": 311104,
             "high_flow": 2277402,
             "network_to_id": "5089888",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 0.00018000000272877514,
+            "ds_slope_source_nwm_id": "5089888",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4183,7 +4251,8 @@
             "low_flow": 739,
             "high_flow": 52886,
             "network_to_id": "5088542",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0001500000071246177,
+            "ds_slope_source_nwm_id": "5088542",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4245,6 +4314,7 @@
             "high_flow": 13680,
             "network_to_id": "5088536",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "5088536",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4305,7 +4375,8 @@
             "low_flow": 307951,
             "high_flow": 2273138,
             "network_to_id": "3630825",
-            "ds_slope": 0.0003499999875202775,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3630825",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4366,7 +4437,8 @@
             "low_flow": 307941,
             "high_flow": 2273201,
             "network_to_id": "3630817",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0003499999875202775,
+            "ds_slope_source_nwm_id": "3630823",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4430,6 +4502,7 @@
             "high_flow": 2273327,
             "network_to_id": "3629267",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629267",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4490,7 +4563,8 @@
             "low_flow": 307947,
             "high_flow": 2273524,
             "network_to_id": "3629263",
-            "ds_slope": 0.00015999999595806003,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629263",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4551,7 +4625,8 @@
             "low_flow": 307836,
             "high_flow": 2272965,
             "network_to_id": "3629241",
-            "ds_slope": 0.00031999999191612005,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629241",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4612,7 +4687,8 @@
             "low_flow": 304675,
             "high_flow": 2328624,
             "network_to_id": "3624735",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope_source_nwm_id": "3624735",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4674,6 +4750,7 @@
             "high_flow": 2329706,
             "network_to_id": "3624709",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624709",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4735,6 +4812,7 @@
             "high_flow": 2328865,
             "network_to_id": "3634823",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3634823",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4795,7 +4873,8 @@
             "low_flow": 304642,
             "high_flow": 2328491,
             "network_to_id": "3624727",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.000539999979082495,
+            "ds_slope_source_nwm_id": "3624727",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4856,7 +4935,8 @@
             "low_flow": 307819,
             "high_flow": 2273066,
             "network_to_id": "3629227",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00031999999191612005,
+            "ds_slope_source_nwm_id": "3629237",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4919,7 +4999,8 @@
             "low_flow": 307944,
             "high_flow": 2273549,
             "network_to_id": "3629257",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00015999999595806003,
+            "ds_slope_source_nwm_id": "3629257",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4981,6 +5062,7 @@
             "high_flow": 2273029,
             "network_to_id": "3629247",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629247",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5042,6 +5124,7 @@
             "high_flow": 2273281,
             "network_to_id": "3629221",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629221",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5103,6 +5186,7 @@
             "high_flow": 2273155,
             "network_to_id": "3629229",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629229",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5164,6 +5248,7 @@
             "high_flow": 2329497,
             "network_to_id": "3624715",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624715",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5225,6 +5310,7 @@
             "high_flow": 2329474,
             "network_to_id": "3634869",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3634869",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5286,6 +5372,7 @@
             "high_flow": 2329541,
             "network_to_id": "3624711",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624711",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5346,7 +5433,8 @@
             "low_flow": 307826,
             "high_flow": 2273330,
             "network_to_id": "3629217",
-            "ds_slope": 0.00014000000373926014,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629217",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5407,7 +5495,8 @@
             "low_flow": 307824,
             "high_flow": 2273347,
             "network_to_id": "3629209",
-            "ds_slope": 0.002589999930933118,
+            "ds_slope": 0.00014000000373926014,
+            "ds_slope_source_nwm_id": "3629213",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5470,7 +5559,8 @@
             "low_flow": 307775,
             "high_flow": 2272877,
             "network_to_id": "3629203",
-            "ds_slope": 0.00046999999904073775,
+            "ds_slope": 0.002589999930933118,
+            "ds_slope_source_nwm_id": "3629205",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5534,6 +5624,7 @@
             "high_flow": 2274158,
             "network_to_id": "3629163",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629163",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5594,7 +5685,8 @@
             "low_flow": 307799,
             "high_flow": 2274370,
             "network_to_id": "3629159",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629159",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5655,7 +5747,8 @@
             "low_flow": 307771,
             "high_flow": 2274912,
             "network_to_id": "3629147",
-            "ds_slope": 0.00031999999191612005,
+            "ds_slope": 0.0003000000142492354,
+            "ds_slope_source_nwm_id": "3629147",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5716,7 +5809,8 @@
             "low_flow": 307769,
             "high_flow": 2274690,
             "network_to_id": "3629155",
-            "ds_slope": 0.0003000000142492354,
+            "ds_slope": 5.999999848427251e-05,
+            "ds_slope_source_nwm_id": "3629155",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5777,7 +5871,8 @@
             "low_flow": 307702,
             "high_flow": 2275597,
             "network_to_id": "3629135",
-            "ds_slope": 9.000000136438757e-05,
+            "ds_slope": 0.00031999999191612005,
+            "ds_slope_source_nwm_id": "3629135",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5838,7 +5933,8 @@
             "low_flow": 307709,
             "high_flow": 2275642,
             "network_to_id": "3629127",
-            "ds_slope": 9.999999747378752e-05,
+            "ds_slope": 9.000000136438757e-05,
+            "ds_slope_source_nwm_id": "3629127",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5899,7 +5995,8 @@
             "low_flow": 307711,
             "high_flow": 2275912,
             "network_to_id": "3629119",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 9.999999747378752e-05,
+            "ds_slope_source_nwm_id": "3629119",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5961,6 +6058,7 @@
             "high_flow": 2275514,
             "network_to_id": "3629097",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629097",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6021,7 +6119,8 @@
             "low_flow": 307695,
             "high_flow": 2275714,
             "network_to_id": "3629089",
-            "ds_slope": 7.000000186963007e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629089",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6082,7 +6181,8 @@
             "low_flow": 307696,
             "high_flow": 2276284,
             "network_to_id": "3629077",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 7.000000186963007e-05,
+            "ds_slope_source_nwm_id": "3629083",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6145,7 +6245,8 @@
             "low_flow": 305043,
             "high_flow": 2322995,
             "network_to_id": "3629071",
-            "ds_slope": 0.00022000000171829015,
+            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope_source_nwm_id": "3629071",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6206,7 +6307,8 @@
             "low_flow": 305028,
             "high_flow": 2322643,
             "network_to_id": "3629073",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope_source_nwm_id": "3629073",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6267,7 +6369,8 @@
             "low_flow": 305038,
             "high_flow": 2323267,
             "network_to_id": "3629067",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 0.00022000000171829015,
+            "ds_slope_source_nwm_id": "3629067",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6328,7 +6431,8 @@
             "low_flow": 305017,
             "high_flow": 2323555,
             "network_to_id": "3629053",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0012199999764561653,
+            "ds_slope_source_nwm_id": "3629053",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6389,7 +6493,8 @@
             "low_flow": 305019,
             "high_flow": 2323533,
             "network_to_id": "3629059",
-            "ds_slope": 0.0001900000061141327,
+            "ds_slope": 0.00013000000035390258,
+            "ds_slope_source_nwm_id": "3629059",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6450,7 +6555,8 @@
             "low_flow": 305018,
             "high_flow": 2323565,
             "network_to_id": "3629055",
-            "ds_slope": 0.0012199999764561653,
+            "ds_slope": 0.0001900000061141327,
+            "ds_slope_source_nwm_id": "3629055",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6511,7 +6617,8 @@
             "low_flow": 305035,
             "high_flow": 2323477,
             "network_to_id": "3629065",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 4.999999873689376e-05,
+            "ds_slope_source_nwm_id": "3629065",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6573,6 +6680,7 @@
             "high_flow": 2323658,
             "network_to_id": "3624747",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624747",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6634,6 +6742,7 @@
             "high_flow": 2323007,
             "network_to_id": "3624745",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624745",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6694,9 +6803,10 @@
             "low_flow": 304635,
             "high_flow": 2322873,
             "network_to_id": "3624739",
-            "ds_slope": 1.9999999494757503e-05,
             "gage": "07010000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07010000&legacy=1",
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624739",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6757,7 +6867,8 @@
             "low_flow": 307746,
             "high_flow": 2272802,
             "network_to_id": "3629191",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00046999999904073775,
+            "ds_slope_source_nwm_id": "3629197",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6821,6 +6932,7 @@
             "high_flow": 2272963,
             "network_to_id": "3629319",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629187",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6879,7 +6991,8 @@
             "low_flow": 307759,
             "high_flow": 2273211,
             "network_to_id": "3629181",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3629181",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6940,7 +7053,8 @@
             "low_flow": 307795,
             "high_flow": 2274180,
             "network_to_id": "3629173",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope_source_nwm_id": "3629173",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7002,6 +7116,7 @@
             "high_flow": 2328784,
             "network_to_id": "3624723",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624723",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7062,7 +7177,8 @@
             "low_flow": 128524,
             "high_flow": 927042,
             "network_to_id": "2927571",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0003000000142492354,
+            "ds_slope_source_nwm_id": "2927581",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7126,6 +7242,7 @@
             "high_flow": 926809,
             "network_to_id": "2927819",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927819",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7187,6 +7304,7 @@
             "high_flow": 926922,
             "network_to_id": "2927699",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927699",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7248,6 +7366,7 @@
             "high_flow": 926921,
             "network_to_id": "2927711",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927597",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7311,6 +7430,7 @@
             "high_flow": 926885,
             "network_to_id": "2927601",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927601",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7372,6 +7492,7 @@
             "high_flow": 926800,
             "network_to_id": "2927691",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927691",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7433,6 +7554,7 @@
             "high_flow": 926786,
             "network_to_id": "2927611",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927611",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7494,6 +7616,7 @@
             "high_flow": 926968,
             "network_to_id": "2927727",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927713",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7557,6 +7680,7 @@
             "high_flow": 926863,
             "network_to_id": "2927697",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927689",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7619,7 +7743,8 @@
             "low_flow": 128524,
             "high_flow": 926995,
             "network_to_id": "2927589",
-            "ds_slope": 0.0003000000142492354,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927589",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7680,7 +7805,8 @@
             "low_flow": 129121,
             "high_flow": 940686,
             "network_to_id": "2930505",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930505",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7742,6 +7868,7 @@
             "high_flow": 940676,
             "network_to_id": "2931037",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2931037",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7802,7 +7929,8 @@
             "low_flow": 129118,
             "high_flow": 940777,
             "network_to_id": "2932183",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope_source_nwm_id": "2932183",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7864,6 +7992,7 @@
             "high_flow": 940826,
             "network_to_id": "2932177",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932177",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7925,6 +8054,7 @@
             "high_flow": 926721,
             "network_to_id": "2932155",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932155",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7986,6 +8116,7 @@
             "high_flow": 926724,
             "network_to_id": "2932159",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932159",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8047,6 +8178,7 @@
             "high_flow": 926740,
             "network_to_id": "2927615",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927615",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8108,6 +8240,7 @@
             "high_flow": 926741,
             "network_to_id": "2927647",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927647",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8169,6 +8302,7 @@
             "high_flow": 926773,
             "network_to_id": "2927613",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927667",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8232,6 +8366,7 @@
             "high_flow": 926740,
             "network_to_id": "2927645",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2927645",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8293,6 +8428,7 @@
             "high_flow": 940661,
             "network_to_id": "2930867",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930867",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8354,6 +8490,7 @@
             "high_flow": 926706,
             "network_to_id": "2932231",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932165",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8417,6 +8554,7 @@
             "high_flow": 926700,
             "network_to_id": "2932173",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932173",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8478,6 +8616,7 @@
             "high_flow": 926728,
             "network_to_id": "2932209",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932171",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8540,7 +8679,8 @@
             "low_flow": 129117,
             "high_flow": 940555,
             "network_to_id": "2931035",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0005000000237487257,
+            "ds_slope_source_nwm_id": "2931035",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8602,6 +8742,7 @@
             "high_flow": 940627,
             "network_to_id": "2930871",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930871",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8663,6 +8804,7 @@
             "high_flow": 940575,
             "network_to_id": "2930531",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930531",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8723,7 +8865,8 @@
             "low_flow": 129120,
             "high_flow": 940500,
             "network_to_id": "2930553",
-            "ds_slope": 0.0006200000061653554,
+            "ds_slope": 0.003710000077262521,
+            "ds_slope_source_nwm_id": "2930553",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8784,7 +8927,8 @@
             "low_flow": 129120,
             "high_flow": 940500,
             "network_to_id": "2930557",
-            "ds_slope": 0.003710000077262521,
+            "ds_slope": 0.0013200000394135714,
+            "ds_slope_source_nwm_id": "2930557",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8845,7 +8989,8 @@
             "low_flow": 129120,
             "high_flow": 940501,
             "network_to_id": "2931045",
-            "ds_slope": 0.0013200000394135714,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2931045",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8907,6 +9052,7 @@
             "high_flow": 940337,
             "network_to_id": "2930907",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930909",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8970,6 +9116,7 @@
             "high_flow": 940350,
             "network_to_id": "2930569",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930577",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9032,7 +9179,8 @@
             "low_flow": 129117,
             "high_flow": 940292,
             "network_to_id": "2930581",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 5.999999848427251e-05,
+            "ds_slope_source_nwm_id": "2930581",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9094,6 +9242,7 @@
             "high_flow": 940642,
             "network_to_id": "2930511",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930511",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9155,6 +9304,7 @@
             "high_flow": 940347,
             "network_to_id": "2930887",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2931051",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9214,6 +9364,7 @@
             "high_flow": 940394,
             "network_to_id": "2931041",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2931041",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9275,6 +9426,7 @@
             "high_flow": 940399,
             "network_to_id": "2931043",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2931043",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9336,6 +9488,7 @@
             "high_flow": 940384,
             "network_to_id": "2930889",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930905",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9399,6 +9552,7 @@
             "high_flow": 940389,
             "network_to_id": "2930559",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930559",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9459,7 +9613,8 @@
             "low_flow": 129119,
             "high_flow": 940534,
             "network_to_id": "2930543",
-            "ds_slope": 0.0005000000237487257,
+            "ds_slope": 0.0006200000061653554,
+            "ds_slope_source_nwm_id": "2930875",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9522,7 +9677,8 @@
             "low_flow": 129182,
             "high_flow": 932721,
             "network_to_id": "2932885",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0008200000156648457,
+            "ds_slope_source_nwm_id": "2932885",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9583,7 +9739,8 @@
             "low_flow": 129182,
             "high_flow": 932719,
             "network_to_id": "2932901",
-            "ds_slope": 0.0008200000156648457,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932901",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9645,6 +9802,7 @@
             "high_flow": 932742,
             "network_to_id": "2932905",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932905",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9705,7 +9863,8 @@
             "low_flow": 129183,
             "high_flow": 933393,
             "network_to_id": "2930771",
-            "ds_slope": 0.0006300000241026282,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932869",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9764,7 +9923,8 @@
             "low_flow": 129183,
             "high_flow": 933407,
             "network_to_id": "2930767",
-            "ds_slope": 0.005510000046342611,
+            "ds_slope": 0.0006300000241026282,
+            "ds_slope_source_nwm_id": "2930767",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9826,6 +9986,7 @@
             "high_flow": 933555,
             "network_to_id": "2938441",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2938445",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9888,7 +10049,8 @@
             "low_flow": 129195,
             "high_flow": 933612,
             "network_to_id": "2930603",
-            "ds_slope": 0.00039000000106170774,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930603",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9949,7 +10111,8 @@
             "low_flow": 129174,
             "high_flow": 933800,
             "network_to_id": "2930601",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00039000000106170774,
+            "ds_slope_source_nwm_id": "2930601",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10011,6 +10174,7 @@
             "high_flow": 933473,
             "network_to_id": "2930749",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930749",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10071,7 +10235,8 @@
             "low_flow": 129186,
             "high_flow": 933486,
             "network_to_id": "2930759",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 7.999999797903001e-05,
+            "ds_slope_source_nwm_id": "2930759",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10132,7 +10297,8 @@
             "low_flow": 129183,
             "high_flow": 933490,
             "network_to_id": "2930761",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 0.005510000046342611,
+            "ds_slope_source_nwm_id": "2930763",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10195,7 +10361,8 @@
             "low_flow": 129190,
             "high_flow": 933520,
             "network_to_id": "2938505",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2938505",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10257,6 +10424,7 @@
             "high_flow": 933590,
             "network_to_id": "2930607",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930607",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10318,6 +10486,7 @@
             "high_flow": 932715,
             "network_to_id": "2932893",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932893",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10379,6 +10548,7 @@
             "high_flow": 932725,
             "network_to_id": "2932873",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932873",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10439,7 +10609,8 @@
             "low_flow": 129127,
             "high_flow": 939882,
             "network_to_id": "2930593",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0001500000071246177,
+            "ds_slope_source_nwm_id": "2930593",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10500,7 +10671,8 @@
             "low_flow": 129195,
             "high_flow": 933535,
             "network_to_id": "2930621",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope_source_nwm_id": "2930621",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10561,7 +10733,8 @@
             "low_flow": 129193,
             "high_flow": 933491,
             "network_to_id": "2930639",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 5.999999848427251e-05,
+            "ds_slope_source_nwm_id": "2930639",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10622,7 +10795,8 @@
             "low_flow": 129189,
             "high_flow": 933532,
             "network_to_id": "2938455",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope_source_nwm_id": "2930679",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10685,7 +10859,8 @@
             "low_flow": 129188,
             "high_flow": 933516,
             "network_to_id": "2930705",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930705",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10746,7 +10921,8 @@
             "low_flow": 129188,
             "high_flow": 933472,
             "network_to_id": "2938477",
-            "ds_slope": 9.999999747378752e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930719",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10809,7 +10985,8 @@
             "low_flow": 129188,
             "high_flow": 933475,
             "network_to_id": "2930713",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 9.999999747378752e-05,
+            "ds_slope_source_nwm_id": "2930713",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10871,6 +11048,7 @@
             "high_flow": 933465,
             "network_to_id": "2931017",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930981",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10934,6 +11112,7 @@
             "high_flow": 933545,
             "network_to_id": "2930651",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930651",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10995,6 +11174,7 @@
             "high_flow": 933531,
             "network_to_id": "2938507",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2938507",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11056,6 +11236,7 @@
             "high_flow": 933533,
             "network_to_id": "2930649",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930649",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11117,6 +11298,7 @@
             "high_flow": 932750,
             "network_to_id": "2932875",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2932881",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11180,6 +11362,7 @@
             "high_flow": 933483,
             "network_to_id": "2938485",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930723",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11242,7 +11425,8 @@
             "low_flow": 129188,
             "high_flow": 933486,
             "network_to_id": "2930709",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00011999999696854502,
+            "ds_slope_source_nwm_id": "2930709",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11303,7 +11487,8 @@
             "low_flow": 129189,
             "high_flow": 933497,
             "network_to_id": "2938461",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 7.999999797903001e-05,
+            "ds_slope_source_nwm_id": "2938461",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11364,7 +11549,8 @@
             "low_flow": 129194,
             "high_flow": 933556,
             "network_to_id": "2930625",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 0.0001500000071246177,
+            "ds_slope_source_nwm_id": "2938449",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11428,6 +11614,7 @@
             "high_flow": 939924,
             "network_to_id": "2930591",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2930591",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11488,7 +11675,8 @@
             "low_flow": 129109,
             "high_flow": 940001,
             "network_to_id": "2938437",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "2938437",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11550,6 +11738,7 @@
             "high_flow": 932736,
             "network_to_id": "880776",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880776",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11611,6 +11800,7 @@
             "high_flow": 932723,
             "network_to_id": "880624",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880624",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11672,6 +11862,7 @@
             "high_flow": 932709,
             "network_to_id": "880820",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880820",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11733,6 +11924,7 @@
             "high_flow": 932736,
             "network_to_id": "880784",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880784",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11794,6 +11986,7 @@
             "high_flow": 939351,
             "network_to_id": "880548",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880548",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11855,6 +12048,7 @@
             "high_flow": 939423,
             "network_to_id": "880596",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880596",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11915,7 +12109,8 @@
             "low_flow": 129319,
             "high_flow": 939377,
             "network_to_id": "880630",
-            "ds_slope": 0.0002300000051036477,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880630",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11976,7 +12171,8 @@
             "low_flow": 129320,
             "high_flow": 939410,
             "network_to_id": "880654",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0002300000051036477,
+            "ds_slope_source_nwm_id": "880654",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12038,6 +12234,7 @@
             "high_flow": 939387,
             "network_to_id": "880640",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880640",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12099,6 +12296,7 @@
             "high_flow": 939386,
             "network_to_id": "880662",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880662",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12160,6 +12358,7 @@
             "high_flow": 932714,
             "network_to_id": "880604",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880604",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12221,6 +12420,7 @@
             "high_flow": 932722,
             "network_to_id": "880786",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880786",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12282,6 +12482,7 @@
             "high_flow": 939396,
             "network_to_id": "880644",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880668",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12345,6 +12546,7 @@
             "high_flow": 939386,
             "network_to_id": "880818",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880818",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12406,6 +12608,7 @@
             "high_flow": 932727,
             "network_to_id": "880614",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880614",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12466,7 +12669,8 @@
             "low_flow": 184036,
             "high_flow": 1034814,
             "network_to_id": "880544",
-            "ds_slope": 7.000000186963007e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880544",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12528,6 +12732,7 @@
             "high_flow": 940855,
             "network_to_id": "880494",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880494",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12589,6 +12794,7 @@
             "high_flow": 939356,
             "network_to_id": "880534",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880534",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12650,6 +12856,7 @@
             "high_flow": 1034826,
             "network_to_id": "880486",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880486",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12711,6 +12918,7 @@
             "high_flow": 940877,
             "network_to_id": "880478",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880484",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12774,6 +12982,7 @@
             "high_flow": 1034797,
             "network_to_id": "882688",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880512",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12837,6 +13046,7 @@
             "high_flow": 940895,
             "network_to_id": "880816",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880816",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12898,6 +13108,7 @@
             "high_flow": 1035097,
             "network_to_id": "880768",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880768",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -12959,6 +13170,7 @@
             "high_flow": 1035111,
             "network_to_id": "24745881",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "24745881",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13019,7 +13231,8 @@
             "low_flow": 184039,
             "high_flow": 1034883,
             "network_to_id": "880536",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 7.000000186963007e-05,
+            "ds_slope_source_nwm_id": "880536",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13081,6 +13294,7 @@
             "high_flow": 1034786,
             "network_to_id": "882686",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "882686",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13142,6 +13356,7 @@
             "high_flow": 1034813,
             "network_to_id": "880490",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880490",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13202,7 +13417,8 @@
             "low_flow": 184074,
             "high_flow": 1023294,
             "network_to_id": "882710",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 4.999999873689376e-05,
+            "ds_slope_source_nwm_id": "882710",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13264,6 +13480,7 @@
             "high_flow": 1023228,
             "network_to_id": "880666",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880666",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13324,7 +13541,8 @@
             "low_flow": 184037,
             "high_flow": 1022793,
             "network_to_id": "880636",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0033499998971819878,
+            "ds_slope_source_nwm_id": "880636",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13385,7 +13603,8 @@
             "low_flow": 184040,
             "high_flow": 1022921,
             "network_to_id": "880606",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope_source_nwm_id": "880606",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13446,7 +13665,8 @@
             "low_flow": 184037,
             "high_flow": 1035127,
             "network_to_id": "880814",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00011999999696854502,
+            "ds_slope_source_nwm_id": "880562",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13510,6 +13730,7 @@
             "high_flow": 1035116,
             "network_to_id": "880550",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880550",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13570,7 +13791,8 @@
             "low_flow": 184070,
             "high_flow": 1023196,
             "network_to_id": "3624763",
-            "ds_slope": 2.9999999242136255e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624763",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13632,6 +13854,7 @@
             "high_flow": 1022773,
             "network_to_id": "880652",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880652",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13692,7 +13915,8 @@
             "low_flow": 184077,
             "high_flow": 1023300,
             "network_to_id": "880678",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 2.9999999242136255e-05,
+            "ds_slope_source_nwm_id": "880678",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13753,7 +13977,8 @@
             "low_flow": 184037,
             "high_flow": 1022817,
             "network_to_id": "880648",
-            "ds_slope": 0.0033499998971819878,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880648",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13814,7 +14039,8 @@
             "low_flow": 184036,
             "high_flow": 1035071,
             "network_to_id": "880580",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880580",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13876,6 +14102,7 @@
             "high_flow": 1022774,
             "network_to_id": "880622",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880622",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -13936,7 +14163,8 @@
             "low_flow": 184037,
             "high_flow": 1022838,
             "network_to_id": "880608",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "880618",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -14000,6 +14228,7 @@
             "high_flow": 2330751,
             "network_to_id": "3624695",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624695",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -14061,6 +14290,7 @@
             "high_flow": 2330669,
             "network_to_id": "3624705",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624705",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -14122,6 +14352,7 @@
             "high_flow": 2330857,
             "network_to_id": "3624701",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "3624701",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -14167,330 +14398,283 @@
             "eclipsed": true,
             "low_flow": 313141,
             "high_flow": 2271715,
-            "network_to_id": "5092614",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "5092614"
         },
         "5089960": {
             "eclipsed": true,
             "low_flow": 311301,
             "high_flow": 2277256,
-            "network_to_id": "5089970",
-            "ds_slope": 0.0009800000116229057
+            "network_to_id": "5089970"
         },
         "5092602": {
             "eclipsed": true,
             "low_flow": 311974,
             "high_flow": 2262502,
-            "network_to_id": "5092606",
-            "ds_slope": 0.0003699999942909926
+            "network_to_id": "5092606"
         },
         "5089990": {
             "eclipsed": true,
             "low_flow": 312040,
             "high_flow": 2262298,
-            "network_to_id": "5089998",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "5089998"
         },
         "5089932": {
             "eclipsed": true,
             "low_flow": 311302,
             "high_flow": 2277441,
-            "network_to_id": "5089938",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "5089938"
         },
         "5092652": {
             "eclipsed": true,
             "low_flow": 313251,
             "high_flow": 2273185,
-            "network_to_id": "5092676",
-            "ds_slope": 0.00026000000070780516
+            "network_to_id": "5092676"
         },
         "5092626": {
             "eclipsed": true,
             "low_flow": 313347,
             "high_flow": 2273525,
-            "network_to_id": "5092630",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "5092630"
         },
         "5092710": {
             "eclipsed": true,
             "low_flow": 313061,
             "high_flow": 2272557,
-            "network_to_id": "5092704",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "5092704"
         },
         "5089872": {
             "eclipsed": true,
             "low_flow": 307967,
             "high_flow": 2273168,
-            "network_to_id": "5089868",
-            "ds_slope": 1.9999999494757503e-05
+            "network_to_id": "5089868"
         },
         "5088488": {
             "eclipsed": true,
             "low_flow": 270,
             "high_flow": 14138,
-            "network_to_id": "5088524",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "5088524"
         },
         "5089870": {
             "eclipsed": true,
             "low_flow": 311105,
             "high_flow": 2277490,
-            "network_to_id": "5089880",
-            "ds_slope": 3.9999998989515007e-05
+            "network_to_id": "5089880"
         },
         "3630817": {
             "eclipsed": true,
             "low_flow": 307940,
             "high_flow": 2273156,
-            "network_to_id": "3630823",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "3630823"
         },
         "3629227": {
             "eclipsed": true,
             "low_flow": 307820,
             "high_flow": 2273042,
-            "network_to_id": "3629237",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "3629237"
         },
         "3629209": {
             "eclipsed": true,
             "low_flow": 307826,
             "high_flow": 2273359,
-            "network_to_id": "3629213",
-            "ds_slope": 0.000590000010561198
+            "network_to_id": "3629213"
         },
         "3629203": {
             "eclipsed": true,
             "low_flow": 307775,
             "high_flow": 2272976,
-            "network_to_id": "3629205",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "3629205"
         },
         "3629077": {
             "eclipsed": true,
             "low_flow": 307698,
             "high_flow": 2276287,
-            "network_to_id": "3629083",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "3629083"
         },
         "3629191": {
             "eclipsed": true,
             "low_flow": 307773,
             "high_flow": 2272912,
-            "network_to_id": "3629197",
-            "ds_slope": 0.002859999891370535
+            "network_to_id": "3629197"
         },
         "3629319": {
             "eclipsed": true,
             "low_flow": 307755,
             "high_flow": 2273037,
-            "network_to_id": "3629183",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "3629183"
         },
         "3629183": {
             "eclipsed": true,
             "low_flow": 307755,
             "high_flow": 2273085,
-            "network_to_id": "3629187",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "3629187"
         },
         "2927571": {
             "eclipsed": true,
             "low_flow": 128524,
             "high_flow": 927049,
-            "network_to_id": "2927581",
-            "ds_slope": 0.0038499999791383743
+            "network_to_id": "2927581"
         },
         "2927711": {
             "eclipsed": true,
             "low_flow": 128521,
             "high_flow": 926908,
-            "network_to_id": "2927597",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2927597"
         },
         "2927727": {
             "eclipsed": true,
             "low_flow": 128523,
             "high_flow": 926966,
-            "network_to_id": "2927713",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2927713"
         },
         "2927697": {
             "eclipsed": true,
             "low_flow": 128519,
             "high_flow": 926854,
-            "network_to_id": "2927689",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2927689"
         },
         "2927613": {
             "eclipsed": true,
             "low_flow": 128517,
             "high_flow": 926772,
-            "network_to_id": "2927667",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2927667"
         },
         "2932231": {
             "eclipsed": true,
             "low_flow": 128515,
             "high_flow": 926722,
-            "network_to_id": "2932165",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2932165"
         },
         "2932209": {
             "eclipsed": true,
             "low_flow": 128515,
             "high_flow": 926732,
-            "network_to_id": "2932171",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2932171"
         },
         "2930907": {
             "eclipsed": true,
             "low_flow": 129119,
             "high_flow": 940332,
-            "network_to_id": "2930909",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930909"
         },
         "2930569": {
             "eclipsed": true,
             "low_flow": 129119,
             "high_flow": 940362,
-            "network_to_id": "2930577",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930577"
         },
         "2930887": {
             "eclipsed": true,
             "low_flow": 129119,
             "high_flow": 940347,
-            "network_to_id": "2930565",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930565"
         },
         "2930565": {
             "eclipsed": true,
             "low_flow": 129119,
             "high_flow": 940365,
-            "network_to_id": "2931051",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2931051"
         },
         "2930889": {
             "eclipsed": true,
             "low_flow": 129119,
             "high_flow": 940386,
-            "network_to_id": "2930905",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930905"
         },
         "2930543": {
             "eclipsed": true,
             "low_flow": 129119,
             "high_flow": 940541,
-            "network_to_id": "2930875",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930875"
         },
         "2930771": {
             "eclipsed": true,
             "low_flow": 129184,
             "high_flow": 932743,
-            "network_to_id": "2932865",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2932865"
         },
         "2932865": {
             "eclipsed": true,
             "low_flow": 129184,
             "high_flow": 932769,
-            "network_to_id": "2932869",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2932869"
         },
         "2938441": {
             "eclipsed": true,
             "low_flow": 129195,
             "high_flow": 933511,
-            "network_to_id": "2938445",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2938445"
         },
         "2930761": {
             "eclipsed": true,
             "low_flow": 129183,
             "high_flow": 933405,
-            "network_to_id": "2930763",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930763"
         },
         "2938455": {
             "eclipsed": true,
             "low_flow": 129189,
             "high_flow": 933526,
-            "network_to_id": "2930679",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930679"
         },
         "2938477": {
             "eclipsed": true,
             "low_flow": 129188,
             "high_flow": 933480,
-            "network_to_id": "2930719",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930719"
         },
         "2931017": {
             "eclipsed": true,
             "low_flow": 129188,
             "high_flow": 933458,
-            "network_to_id": "2930981",
-            "ds_slope": 1.9999999494757503e-05
+            "network_to_id": "2930981"
         },
         "2932875": {
             "eclipsed": true,
             "low_flow": 129183,
             "high_flow": 932749,
-            "network_to_id": "2932881",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2932881"
         },
         "2938485": {
             "eclipsed": true,
             "low_flow": 129188,
             "high_flow": 933484,
-            "network_to_id": "2930723",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2930723"
         },
         "2930625": {
             "eclipsed": true,
             "low_flow": 129194,
             "high_flow": 933522,
-            "network_to_id": "2938449",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "2938449"
         },
         "880644": {
             "eclipsed": true,
             "low_flow": 129323,
             "high_flow": 939408,
-            "network_to_id": "880668",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "880668"
         },
         "880478": {
             "eclipsed": true,
             "low_flow": 184040,
             "high_flow": 1034822,
-            "network_to_id": "880484",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "880484"
         },
         "882688": {
             "eclipsed": true,
             "low_flow": 184039,
             "high_flow": 1034897,
-            "network_to_id": "880512",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "880512"
         },
         "880814": {
             "eclipsed": true,
             "low_flow": 184037,
             "high_flow": 1035119,
-            "network_to_id": "880562",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "880562"
         },
         "880608": {
             "eclipsed": true,
             "low_flow": 0,
             "high_flow": 1022836,
-            "network_to_id": "880618",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "880618"
         }
     },
     "metadata": {

--- a/tests/ras-data/MissFldwy/MissFldwy.conflation.json
+++ b/tests/ras-data/MissFldwy/MissFldwy.conflation.json
@@ -19,7 +19,7 @@
             "low_flow": 313116,
             "high_flow": 2271710,
             "network_to_id": "5096814",
-            "ds_slope": 0.0016899999463930726,
+            "ds_slope": 0.00169,
             "ds_slope_source_nwm_id": "5096814",
             "metrics": {
                 "xs": {
@@ -81,7 +81,7 @@
             "low_flow": 313137,
             "high_flow": 2271658,
             "network_to_id": "5092604",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092614",
             "metrics": {
                 "xs": {
@@ -145,7 +145,7 @@
             "low_flow": 311964,
             "high_flow": 2262053,
             "network_to_id": "5092598",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 2e-05,
             "ds_slope_source_nwm_id": "5092598",
             "metrics": {
                 "xs": {
@@ -207,7 +207,7 @@
             "low_flow": 311945,
             "high_flow": 2261930,
             "network_to_id": "5092748",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092748",
             "metrics": {
                 "xs": {
@@ -269,7 +269,7 @@
             "low_flow": 311964,
             "high_flow": 2262109,
             "network_to_id": "5092594",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 0.00012,
             "ds_slope_source_nwm_id": "5092594",
             "metrics": {
                 "xs": {
@@ -331,7 +331,7 @@
             "low_flow": 311953,
             "high_flow": 2262028,
             "network_to_id": "5092590",
-            "ds_slope": 0.0008099999977275729,
+            "ds_slope": 0.00081,
             "ds_slope_source_nwm_id": "5092590",
             "metrics": {
                 "xs": {
@@ -393,7 +393,7 @@
             "low_flow": 312044,
             "high_flow": 2263096,
             "network_to_id": "5092586",
-            "ds_slope": 9.000000136438757e-05,
+            "ds_slope": 9e-05,
             "ds_slope_source_nwm_id": "5092586",
             "metrics": {
                 "xs": {
@@ -455,7 +455,7 @@
             "low_flow": 312063,
             "high_flow": 2263113,
             "network_to_id": "5092562",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092562",
             "metrics": {
                 "xs": {
@@ -517,7 +517,7 @@
             "low_flow": 312049,
             "high_flow": 2262999,
             "network_to_id": "5092552",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092552",
             "metrics": {
                 "xs": {
@@ -579,7 +579,7 @@
             "low_flow": 312055,
             "high_flow": 2263142,
             "network_to_id": "5092542",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 8e-05,
             "ds_slope_source_nwm_id": "5092542",
             "metrics": {
                 "xs": {
@@ -641,7 +641,7 @@
             "low_flow": 312054,
             "high_flow": 2263096,
             "network_to_id": "5090014",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 0.00013,
             "ds_slope_source_nwm_id": "5090014",
             "metrics": {
                 "xs": {
@@ -703,7 +703,7 @@
             "low_flow": 312061,
             "high_flow": 2263132,
             "network_to_id": "5090010",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5090010",
             "metrics": {
                 "xs": {
@@ -765,7 +765,7 @@
             "low_flow": 312063,
             "high_flow": 2263172,
             "network_to_id": "5090004",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5090004",
             "metrics": {
                 "xs": {
@@ -827,7 +827,7 @@
             "low_flow": 312063,
             "high_flow": 2263144,
             "network_to_id": "5090000",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 0.00054,
             "ds_slope_source_nwm_id": "5090000",
             "metrics": {
                 "xs": {
@@ -889,7 +889,7 @@
             "low_flow": 311261,
             "high_flow": 2276430,
             "network_to_id": "5089986",
-            "ds_slope": 0.0002500000118743628,
+            "ds_slope": 0.00025,
             "ds_slope_source_nwm_id": "5089986",
             "metrics": {
                 "xs": {
@@ -951,7 +951,7 @@
             "low_flow": 311267,
             "high_flow": 2276412,
             "network_to_id": "5089984",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089984",
             "metrics": {
                 "xs": {
@@ -1013,7 +1013,7 @@
             "low_flow": 313129,
             "high_flow": 2272768,
             "network_to_id": "5092712",
-            "ds_slope": 0.00016999999934341758,
+            "ds_slope": 0.00017,
             "ds_slope_source_nwm_id": "5092712",
             "metrics": {
                 "xs": {
@@ -1075,7 +1075,7 @@
             "low_flow": 313132,
             "high_flow": 2272717,
             "network_to_id": "5092698",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00015,
             "ds_slope_source_nwm_id": "5092698",
             "metrics": {
                 "xs": {
@@ -1137,7 +1137,7 @@
             "low_flow": 313317,
             "high_flow": 2273497,
             "network_to_id": "5092646",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092646",
             "metrics": {
                 "xs": {
@@ -1199,7 +1199,7 @@
             "low_flow": 313319,
             "high_flow": 2273521,
             "network_to_id": "5092634",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092634",
             "metrics": {
                 "xs": {
@@ -1261,7 +1261,7 @@
             "low_flow": 311298,
             "high_flow": 2277330,
             "network_to_id": "5096766",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 5e-05,
             "ds_slope_source_nwm_id": "5096766",
             "metrics": {
                 "xs": {
@@ -1323,7 +1323,7 @@
             "low_flow": 311308,
             "high_flow": 2277306,
             "network_to_id": "5089952",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089952",
             "metrics": {
                 "xs": {
@@ -1385,7 +1385,7 @@
             "low_flow": 311299,
             "high_flow": 2277231,
             "network_to_id": "5089960",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089970",
             "metrics": {
                 "xs": {
@@ -1449,7 +1449,7 @@
             "low_flow": 312059,
             "high_flow": 2263257,
             "network_to_id": "5092566",
-            "ds_slope": 0.0002099999983329326,
+            "ds_slope": 0.00021,
             "ds_slope_source_nwm_id": "5092566",
             "metrics": {
                 "xs": {
@@ -1511,7 +1511,7 @@
             "low_flow": 313362,
             "high_flow": 2273460,
             "network_to_id": "5092616",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092616",
             "metrics": {
                 "xs": {
@@ -1573,7 +1573,7 @@
             "low_flow": 311960,
             "high_flow": 2262203,
             "network_to_id": "5092602",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 6e-05,
             "ds_slope_source_nwm_id": "5092606",
             "metrics": {
                 "xs": {
@@ -1637,7 +1637,7 @@
             "low_flow": 312059,
             "high_flow": 2263257,
             "network_to_id": "5092568",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092568",
             "metrics": {
                 "xs": {
@@ -1699,7 +1699,7 @@
             "low_flow": 312059,
             "high_flow": 2263204,
             "network_to_id": "5092572",
-            "ds_slope": 0.00014000000373926014,
+            "ds_slope": 0.00014,
             "ds_slope_source_nwm_id": "5092572",
             "metrics": {
                 "xs": {
@@ -1761,7 +1761,7 @@
             "low_flow": 312048,
             "high_flow": 2263183,
             "network_to_id": "5092582",
-            "ds_slope": 2.9999999242136255e-05,
+            "ds_slope": 3e-05,
             "ds_slope_source_nwm_id": "5092582",
             "metrics": {
                 "xs": {
@@ -1823,7 +1823,7 @@
             "low_flow": 311263,
             "high_flow": 2276431,
             "network_to_id": "5089990",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089998",
             "metrics": {
                 "xs": {
@@ -1887,7 +1887,7 @@
             "low_flow": 311296,
             "high_flow": 2277122,
             "network_to_id": "5089978",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 4e-05,
             "ds_slope_source_nwm_id": "5089978",
             "metrics": {
                 "xs": {
@@ -1949,7 +1949,7 @@
             "low_flow": 311300,
             "high_flow": 2277464,
             "network_to_id": "5089932",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089938",
             "metrics": {
                 "xs": {
@@ -2013,7 +2013,7 @@
             "low_flow": 311295,
             "high_flow": 2277301,
             "network_to_id": "5089946",
-            "ds_slope": 0.00026000000070780516,
+            "ds_slope": 0.00026,
             "ds_slope_source_nwm_id": "5089946",
             "metrics": {
                 "xs": {
@@ -2075,7 +2075,7 @@
             "low_flow": 313251,
             "high_flow": 2273215,
             "network_to_id": "5092652",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 8e-05,
             "ds_slope_source_nwm_id": "5092676",
             "metrics": {
                 "xs": {
@@ -2139,7 +2139,7 @@
             "low_flow": 313345,
             "high_flow": 2273522,
             "network_to_id": "5092626",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092630",
             "metrics": {
                 "xs": {
@@ -2205,7 +2205,7 @@
             "network_to_id": "5092622",
             "gage": "07022000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07022000&legacy=1",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092622",
             "metrics": {
                 "xs": {
@@ -2267,7 +2267,7 @@
             "low_flow": 313333,
             "high_flow": 2242929,
             "network_to_id": "5093440",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5093440",
             "metrics": {
                 "xs": {
@@ -2329,7 +2329,7 @@
             "low_flow": 313329,
             "high_flow": 2242849,
             "network_to_id": "5093450",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5093450",
             "metrics": {
                 "xs": {
@@ -2391,7 +2391,7 @@
             "low_flow": 313358,
             "high_flow": 2243140,
             "network_to_id": "5092686",
-            "ds_slope": 0.00016999999934341758,
+            "ds_slope": 0.00017,
             "ds_slope_source_nwm_id": "5092686",
             "metrics": {
                 "xs": {
@@ -2453,7 +2453,7 @@
             "low_flow": 313346,
             "high_flow": 2242953,
             "network_to_id": "5092702",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092702",
             "metrics": {
                 "xs": {
@@ -2515,7 +2515,7 @@
             "low_flow": 313356,
             "high_flow": 2243136,
             "network_to_id": "5092696",
-            "ds_slope": 7.000000186963007e-05,
+            "ds_slope": 7e-05,
             "ds_slope_source_nwm_id": "5092696",
             "metrics": {
                 "xs": {
@@ -2577,7 +2577,7 @@
             "low_flow": 313337,
             "high_flow": 2243004,
             "network_to_id": "5092706",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092706",
             "metrics": {
                 "xs": {
@@ -2639,7 +2639,7 @@
             "low_flow": 313372,
             "high_flow": 2243130,
             "network_to_id": "5092674",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092674",
             "metrics": {
                 "xs": {
@@ -2701,7 +2701,7 @@
             "low_flow": 313007,
             "high_flow": 2272449,
             "network_to_id": "5092660",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 8e-05,
             "ds_slope_source_nwm_id": "5092660",
             "metrics": {
                 "xs": {
@@ -2763,7 +2763,7 @@
             "low_flow": 313306,
             "high_flow": 2242718,
             "network_to_id": "5093446",
-            "ds_slope": 0.00033000000985339284,
+            "ds_slope": 0.00033,
             "ds_slope_source_nwm_id": "5093448",
             "metrics": {
                 "xs": {
@@ -2820,7 +2820,7 @@
             "low_flow": 313008,
             "high_flow": 2272411,
             "network_to_id": "5092656",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 4e-05,
             "ds_slope_source_nwm_id": "5092656",
             "metrics": {
                 "xs": {
@@ -2882,7 +2882,7 @@
             "low_flow": 313062,
             "high_flow": 2272490,
             "network_to_id": "5092710",
-            "ds_slope": 0.00016999999934341758,
+            "ds_slope": 0.00017,
             "ds_slope_source_nwm_id": "5092704",
             "metrics": {
                 "xs": {
@@ -2946,7 +2946,7 @@
             "low_flow": 313109,
             "high_flow": 2272707,
             "network_to_id": "5093444",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5093444",
             "metrics": {
                 "xs": {
@@ -3008,7 +3008,7 @@
             "low_flow": 313045,
             "high_flow": 2272440,
             "network_to_id": "5092684",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092684",
             "metrics": {
                 "xs": {
@@ -3070,7 +3070,7 @@
             "low_flow": 313038,
             "high_flow": 2272582,
             "network_to_id": "5092658",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5092658",
             "metrics": {
                 "xs": {
@@ -3132,7 +3132,7 @@
             "low_flow": 313040,
             "high_flow": 2272558,
             "network_to_id": "5092664",
-            "ds_slope": 0.0002800000074785203,
+            "ds_slope": 0.00028,
             "ds_slope_source_nwm_id": "5092664",
             "metrics": {
                 "xs": {
@@ -3194,7 +3194,7 @@
             "low_flow": 313040,
             "high_flow": 2272524,
             "network_to_id": "5092670",
-            "ds_slope": 0.00023999999393709004,
+            "ds_slope": 0.00024,
             "ds_slope_source_nwm_id": "5092670",
             "metrics": {
                 "xs": {
@@ -3256,7 +3256,7 @@
             "low_flow": 313307,
             "high_flow": 2242809,
             "network_to_id": "5093448",
-            "ds_slope": 0.00033000000985339284,
+            "ds_slope": 0.00033,
             "ds_slope_source_nwm_id": "5093448",
             "metrics": {
                 "xs": {
@@ -3318,7 +3318,7 @@
             "low_flow": 311306,
             "high_flow": 2277489,
             "network_to_id": "5089926",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089926",
             "metrics": {
                 "xs": {
@@ -3380,7 +3380,7 @@
             "low_flow": 311305,
             "high_flow": 2277445,
             "network_to_id": "5089922",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5089922",
             "metrics": {
                 "xs": {
@@ -3442,7 +3442,7 @@
             "low_flow": 311248,
             "high_flow": 2277381,
             "network_to_id": "5089920",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 2e-05,
             "ds_slope_source_nwm_id": "5089920",
             "metrics": {
                 "xs": {
@@ -3504,7 +3504,7 @@
             "low_flow": 311249,
             "high_flow": 2277484,
             "network_to_id": "5089914",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 0.00013,
             "ds_slope_source_nwm_id": "5089914",
             "metrics": {
                 "xs": {
@@ -3568,7 +3568,7 @@
             "network_to_id": "5089912",
             "gage": "07020500",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07020500&legacy=1",
-            "ds_slope": 0.00011000000085914508,
+            "ds_slope": 0.00011,
             "ds_slope_source_nwm_id": "5089912",
             "metrics": {
                 "xs": {
@@ -3630,7 +3630,7 @@
             "low_flow": 311017,
             "high_flow": 2275401,
             "network_to_id": "5089904",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 0.00012,
             "ds_slope_source_nwm_id": "5089904",
             "metrics": {
                 "xs": {
@@ -3692,7 +3692,7 @@
             "low_flow": 742,
             "high_flow": 51750,
             "network_to_id": "5089894",
-            "ds_slope": 0.0007999999797903001,
+            "ds_slope": 0.0008,
             "ds_slope_source_nwm_id": "5089892",
             "metrics": {
                 "xs": {
@@ -3749,7 +3749,7 @@
             "low_flow": 307951,
             "high_flow": 2273230,
             "network_to_id": "3630829",
-            "ds_slope": 0.0002500000118743628,
+            "ds_slope": 0.00025,
             "ds_slope_source_nwm_id": "3630829",
             "metrics": {
                 "xs": {
@@ -3811,7 +3811,7 @@
             "low_flow": 307963,
             "high_flow": 2273017,
             "network_to_id": "5090052",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5090052",
             "metrics": {
                 "xs": {
@@ -3873,7 +3873,7 @@
             "low_flow": 307965,
             "high_flow": 2273343,
             "network_to_id": "3629943",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 0.00013,
             "ds_slope_source_nwm_id": "3629943",
             "metrics": {
                 "xs": {
@@ -3935,7 +3935,7 @@
             "low_flow": 307966,
             "high_flow": 2273110,
             "network_to_id": "5089872",
-            "ds_slope": 0.0004400000034365803,
+            "ds_slope": 0.00044,
             "ds_slope_source_nwm_id": "5089868",
             "metrics": {
                 "xs": {
@@ -3999,7 +3999,7 @@
             "low_flow": 311105,
             "high_flow": 2277346,
             "network_to_id": "5089890",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 5e-05,
             "ds_slope_source_nwm_id": "5089890",
             "metrics": {
                 "xs": {
@@ -4061,7 +4061,7 @@
             "low_flow": 272,
             "high_flow": 14237,
             "network_to_id": "5088488",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5088524",
             "metrics": {
                 "xs": {
@@ -4125,7 +4125,7 @@
             "low_flow": 311106,
             "high_flow": 2277533,
             "network_to_id": "5089870",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 8e-05,
             "ds_slope_source_nwm_id": "5089880",
             "metrics": {
                 "xs": {
@@ -4189,7 +4189,7 @@
             "low_flow": 311104,
             "high_flow": 2277402,
             "network_to_id": "5089888",
-            "ds_slope": 0.00018000000272877514,
+            "ds_slope": 0.00018,
             "ds_slope_source_nwm_id": "5089888",
             "metrics": {
                 "xs": {
@@ -4251,7 +4251,7 @@
             "low_flow": 739,
             "high_flow": 52886,
             "network_to_id": "5088542",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00015,
             "ds_slope_source_nwm_id": "5088542",
             "metrics": {
                 "xs": {
@@ -4313,7 +4313,7 @@
             "low_flow": 265,
             "high_flow": 13680,
             "network_to_id": "5088536",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "5088536",
             "metrics": {
                 "xs": {
@@ -4375,7 +4375,7 @@
             "low_flow": 307951,
             "high_flow": 2273138,
             "network_to_id": "3630825",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3630825",
             "metrics": {
                 "xs": {
@@ -4437,7 +4437,7 @@
             "low_flow": 307941,
             "high_flow": 2273201,
             "network_to_id": "3630817",
-            "ds_slope": 0.0003499999875202775,
+            "ds_slope": 0.00035,
             "ds_slope_source_nwm_id": "3630823",
             "metrics": {
                 "xs": {
@@ -4501,7 +4501,7 @@
             "low_flow": 307940,
             "high_flow": 2273327,
             "network_to_id": "3629267",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629267",
             "metrics": {
                 "xs": {
@@ -4563,7 +4563,7 @@
             "low_flow": 307947,
             "high_flow": 2273524,
             "network_to_id": "3629263",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629263",
             "metrics": {
                 "xs": {
@@ -4625,7 +4625,7 @@
             "low_flow": 307836,
             "high_flow": 2272965,
             "network_to_id": "3629241",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629241",
             "metrics": {
                 "xs": {
@@ -4687,7 +4687,7 @@
             "low_flow": 304675,
             "high_flow": 2328624,
             "network_to_id": "3624735",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 2e-05,
             "ds_slope_source_nwm_id": "3624735",
             "metrics": {
                 "xs": {
@@ -4749,7 +4749,7 @@
             "low_flow": 304538,
             "high_flow": 2329706,
             "network_to_id": "3624709",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624709",
             "metrics": {
                 "xs": {
@@ -4811,7 +4811,7 @@
             "low_flow": 304537,
             "high_flow": 2328865,
             "network_to_id": "3634823",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3634823",
             "metrics": {
                 "xs": {
@@ -4873,7 +4873,7 @@
             "low_flow": 304642,
             "high_flow": 2328491,
             "network_to_id": "3624727",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 0.00054,
             "ds_slope_source_nwm_id": "3624727",
             "metrics": {
                 "xs": {
@@ -4935,7 +4935,7 @@
             "low_flow": 307819,
             "high_flow": 2273066,
             "network_to_id": "3629227",
-            "ds_slope": 0.00031999999191612005,
+            "ds_slope": 0.00032,
             "ds_slope_source_nwm_id": "3629237",
             "metrics": {
                 "xs": {
@@ -4999,7 +4999,7 @@
             "low_flow": 307944,
             "high_flow": 2273549,
             "network_to_id": "3629257",
-            "ds_slope": 0.00015999999595806003,
+            "ds_slope": 0.00016,
             "ds_slope_source_nwm_id": "3629257",
             "metrics": {
                 "xs": {
@@ -5061,7 +5061,7 @@
             "low_flow": 307839,
             "high_flow": 2273029,
             "network_to_id": "3629247",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629247",
             "metrics": {
                 "xs": {
@@ -5123,7 +5123,7 @@
             "low_flow": 307829,
             "high_flow": 2273281,
             "network_to_id": "3629221",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629221",
             "metrics": {
                 "xs": {
@@ -5185,7 +5185,7 @@
             "low_flow": 307825,
             "high_flow": 2273155,
             "network_to_id": "3629229",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629229",
             "metrics": {
                 "xs": {
@@ -5247,7 +5247,7 @@
             "low_flow": 304547,
             "high_flow": 2329497,
             "network_to_id": "3624715",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624715",
             "metrics": {
                 "xs": {
@@ -5309,7 +5309,7 @@
             "low_flow": 304548,
             "high_flow": 2329474,
             "network_to_id": "3634869",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3634869",
             "metrics": {
                 "xs": {
@@ -5371,7 +5371,7 @@
             "low_flow": 304548,
             "high_flow": 2329541,
             "network_to_id": "3624711",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624711",
             "metrics": {
                 "xs": {
@@ -5433,7 +5433,7 @@
             "low_flow": 307826,
             "high_flow": 2273330,
             "network_to_id": "3629217",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629217",
             "metrics": {
                 "xs": {
@@ -5495,7 +5495,7 @@
             "low_flow": 307824,
             "high_flow": 2273347,
             "network_to_id": "3629209",
-            "ds_slope": 0.00014000000373926014,
+            "ds_slope": 0.00014,
             "ds_slope_source_nwm_id": "3629213",
             "metrics": {
                 "xs": {
@@ -5559,7 +5559,7 @@
             "low_flow": 307775,
             "high_flow": 2272877,
             "network_to_id": "3629203",
-            "ds_slope": 0.002589999930933118,
+            "ds_slope": 0.00259,
             "ds_slope_source_nwm_id": "3629205",
             "metrics": {
                 "xs": {
@@ -5623,7 +5623,7 @@
             "low_flow": 307801,
             "high_flow": 2274158,
             "network_to_id": "3629163",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629163",
             "metrics": {
                 "xs": {
@@ -5685,7 +5685,7 @@
             "low_flow": 307799,
             "high_flow": 2274370,
             "network_to_id": "3629159",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629159",
             "metrics": {
                 "xs": {
@@ -5747,7 +5747,7 @@
             "low_flow": 307771,
             "high_flow": 2274912,
             "network_to_id": "3629147",
-            "ds_slope": 0.0003000000142492354,
+            "ds_slope": 0.0003,
             "ds_slope_source_nwm_id": "3629147",
             "metrics": {
                 "xs": {
@@ -5809,7 +5809,7 @@
             "low_flow": 307769,
             "high_flow": 2274690,
             "network_to_id": "3629155",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 6e-05,
             "ds_slope_source_nwm_id": "3629155",
             "metrics": {
                 "xs": {
@@ -5871,7 +5871,7 @@
             "low_flow": 307702,
             "high_flow": 2275597,
             "network_to_id": "3629135",
-            "ds_slope": 0.00031999999191612005,
+            "ds_slope": 0.00032,
             "ds_slope_source_nwm_id": "3629135",
             "metrics": {
                 "xs": {
@@ -5933,7 +5933,7 @@
             "low_flow": 307709,
             "high_flow": 2275642,
             "network_to_id": "3629127",
-            "ds_slope": 9.000000136438757e-05,
+            "ds_slope": 9e-05,
             "ds_slope_source_nwm_id": "3629127",
             "metrics": {
                 "xs": {
@@ -5995,7 +5995,7 @@
             "low_flow": 307711,
             "high_flow": 2275912,
             "network_to_id": "3629119",
-            "ds_slope": 9.999999747378752e-05,
+            "ds_slope": 0.0001,
             "ds_slope_source_nwm_id": "3629119",
             "metrics": {
                 "xs": {
@@ -6057,7 +6057,7 @@
             "low_flow": 307700,
             "high_flow": 2275514,
             "network_to_id": "3629097",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629097",
             "metrics": {
                 "xs": {
@@ -6119,7 +6119,7 @@
             "low_flow": 307695,
             "high_flow": 2275714,
             "network_to_id": "3629089",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629089",
             "metrics": {
                 "xs": {
@@ -6181,7 +6181,7 @@
             "low_flow": 307696,
             "high_flow": 2276284,
             "network_to_id": "3629077",
-            "ds_slope": 7.000000186963007e-05,
+            "ds_slope": 7e-05,
             "ds_slope_source_nwm_id": "3629083",
             "metrics": {
                 "xs": {
@@ -6245,7 +6245,7 @@
             "low_flow": 305043,
             "high_flow": 2322995,
             "network_to_id": "3629071",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 2e-05,
             "ds_slope_source_nwm_id": "3629071",
             "metrics": {
                 "xs": {
@@ -6307,7 +6307,7 @@
             "low_flow": 305028,
             "high_flow": 2322643,
             "network_to_id": "3629073",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 4e-05,
             "ds_slope_source_nwm_id": "3629073",
             "metrics": {
                 "xs": {
@@ -6369,7 +6369,7 @@
             "low_flow": 305038,
             "high_flow": 2323267,
             "network_to_id": "3629067",
-            "ds_slope": 0.00022000000171829015,
+            "ds_slope": 0.00022,
             "ds_slope_source_nwm_id": "3629067",
             "metrics": {
                 "xs": {
@@ -6431,7 +6431,7 @@
             "low_flow": 305017,
             "high_flow": 2323555,
             "network_to_id": "3629053",
-            "ds_slope": 0.0012199999764561653,
+            "ds_slope": 0.00122,
             "ds_slope_source_nwm_id": "3629053",
             "metrics": {
                 "xs": {
@@ -6493,7 +6493,7 @@
             "low_flow": 305019,
             "high_flow": 2323533,
             "network_to_id": "3629059",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 0.00013,
             "ds_slope_source_nwm_id": "3629059",
             "metrics": {
                 "xs": {
@@ -6555,7 +6555,7 @@
             "low_flow": 305018,
             "high_flow": 2323565,
             "network_to_id": "3629055",
-            "ds_slope": 0.0001900000061141327,
+            "ds_slope": 0.00019,
             "ds_slope_source_nwm_id": "3629055",
             "metrics": {
                 "xs": {
@@ -6617,7 +6617,7 @@
             "low_flow": 305035,
             "high_flow": 2323477,
             "network_to_id": "3629065",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 5e-05,
             "ds_slope_source_nwm_id": "3629065",
             "metrics": {
                 "xs": {
@@ -6679,7 +6679,7 @@
             "low_flow": 305003,
             "high_flow": 2323658,
             "network_to_id": "3624747",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624747",
             "metrics": {
                 "xs": {
@@ -6741,7 +6741,7 @@
             "low_flow": 304715,
             "high_flow": 2323007,
             "network_to_id": "3624745",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624745",
             "metrics": {
                 "xs": {
@@ -6805,7 +6805,7 @@
             "network_to_id": "3624739",
             "gage": "07010000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07010000&legacy=1",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624739",
             "metrics": {
                 "xs": {
@@ -6867,7 +6867,7 @@
             "low_flow": 307746,
             "high_flow": 2272802,
             "network_to_id": "3629191",
-            "ds_slope": 0.00046999999904073775,
+            "ds_slope": 0.00047,
             "ds_slope_source_nwm_id": "3629197",
             "metrics": {
                 "xs": {
@@ -6931,7 +6931,7 @@
             "low_flow": 307755,
             "high_flow": 2272963,
             "network_to_id": "3629319",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629187",
             "metrics": {
                 "xs": {
@@ -6991,7 +6991,7 @@
             "low_flow": 307759,
             "high_flow": 2273211,
             "network_to_id": "3629181",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3629181",
             "metrics": {
                 "xs": {
@@ -7053,7 +7053,7 @@
             "low_flow": 307795,
             "high_flow": 2274180,
             "network_to_id": "3629173",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 2e-05,
             "ds_slope_source_nwm_id": "3629173",
             "metrics": {
                 "xs": {
@@ -7115,7 +7115,7 @@
             "low_flow": 304646,
             "high_flow": 2328784,
             "network_to_id": "3624723",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624723",
             "metrics": {
                 "xs": {
@@ -7177,7 +7177,7 @@
             "low_flow": 128524,
             "high_flow": 927042,
             "network_to_id": "2927571",
-            "ds_slope": 0.0003000000142492354,
+            "ds_slope": 0.0003,
             "ds_slope_source_nwm_id": "2927581",
             "metrics": {
                 "xs": {
@@ -7241,7 +7241,7 @@
             "low_flow": 128517,
             "high_flow": 926809,
             "network_to_id": "2927819",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927819",
             "metrics": {
                 "xs": {
@@ -7303,7 +7303,7 @@
             "low_flow": 128520,
             "high_flow": 926922,
             "network_to_id": "2927699",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927699",
             "metrics": {
                 "xs": {
@@ -7365,7 +7365,7 @@
             "low_flow": 128520,
             "high_flow": 926921,
             "network_to_id": "2927711",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927597",
             "metrics": {
                 "xs": {
@@ -7429,7 +7429,7 @@
             "low_flow": 128520,
             "high_flow": 926885,
             "network_to_id": "2927601",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927601",
             "metrics": {
                 "xs": {
@@ -7491,7 +7491,7 @@
             "low_flow": 128517,
             "high_flow": 926800,
             "network_to_id": "2927691",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927691",
             "metrics": {
                 "xs": {
@@ -7553,7 +7553,7 @@
             "low_flow": 128516,
             "high_flow": 926786,
             "network_to_id": "2927611",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927611",
             "metrics": {
                 "xs": {
@@ -7615,7 +7615,7 @@
             "low_flow": 128523,
             "high_flow": 926968,
             "network_to_id": "2927727",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927713",
             "metrics": {
                 "xs": {
@@ -7679,7 +7679,7 @@
             "low_flow": 128520,
             "high_flow": 926863,
             "network_to_id": "2927697",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927689",
             "metrics": {
                 "xs": {
@@ -7743,7 +7743,7 @@
             "low_flow": 128524,
             "high_flow": 926995,
             "network_to_id": "2927589",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927589",
             "metrics": {
                 "xs": {
@@ -7805,7 +7805,7 @@
             "low_flow": 129121,
             "high_flow": 940686,
             "network_to_id": "2930505",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930505",
             "metrics": {
                 "xs": {
@@ -7867,7 +7867,7 @@
             "low_flow": 129120,
             "high_flow": 940676,
             "network_to_id": "2931037",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2931037",
             "metrics": {
                 "xs": {
@@ -7929,7 +7929,7 @@
             "low_flow": 129118,
             "high_flow": 940777,
             "network_to_id": "2932183",
-            "ds_slope": 1.9999999494757503e-05,
+            "ds_slope": 2e-05,
             "ds_slope_source_nwm_id": "2932183",
             "metrics": {
                 "xs": {
@@ -7991,7 +7991,7 @@
             "low_flow": 129112,
             "high_flow": 940826,
             "network_to_id": "2932177",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932177",
             "metrics": {
                 "xs": {
@@ -8053,7 +8053,7 @@
             "low_flow": 128514,
             "high_flow": 926721,
             "network_to_id": "2932155",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932155",
             "metrics": {
                 "xs": {
@@ -8115,7 +8115,7 @@
             "low_flow": 128515,
             "high_flow": 926724,
             "network_to_id": "2932159",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932159",
             "metrics": {
                 "xs": {
@@ -8177,7 +8177,7 @@
             "low_flow": 128515,
             "high_flow": 926740,
             "network_to_id": "2927615",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927615",
             "metrics": {
                 "xs": {
@@ -8239,7 +8239,7 @@
             "low_flow": 128516,
             "high_flow": 926741,
             "network_to_id": "2927647",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927647",
             "metrics": {
                 "xs": {
@@ -8301,7 +8301,7 @@
             "low_flow": 128517,
             "high_flow": 926773,
             "network_to_id": "2927613",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927667",
             "metrics": {
                 "xs": {
@@ -8365,7 +8365,7 @@
             "low_flow": 128515,
             "high_flow": 926740,
             "network_to_id": "2927645",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2927645",
             "metrics": {
                 "xs": {
@@ -8427,7 +8427,7 @@
             "low_flow": 129121,
             "high_flow": 940661,
             "network_to_id": "2930867",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930867",
             "metrics": {
                 "xs": {
@@ -8489,7 +8489,7 @@
             "low_flow": 128515,
             "high_flow": 926706,
             "network_to_id": "2932231",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932165",
             "metrics": {
                 "xs": {
@@ -8553,7 +8553,7 @@
             "low_flow": 128514,
             "high_flow": 926700,
             "network_to_id": "2932173",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932173",
             "metrics": {
                 "xs": {
@@ -8615,7 +8615,7 @@
             "low_flow": 128515,
             "high_flow": 926728,
             "network_to_id": "2932209",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932171",
             "metrics": {
                 "xs": {
@@ -8679,7 +8679,7 @@
             "low_flow": 129117,
             "high_flow": 940555,
             "network_to_id": "2931035",
-            "ds_slope": 0.0005000000237487257,
+            "ds_slope": 0.0005,
             "ds_slope_source_nwm_id": "2931035",
             "metrics": {
                 "xs": {
@@ -8741,7 +8741,7 @@
             "low_flow": 129120,
             "high_flow": 940627,
             "network_to_id": "2930871",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930871",
             "metrics": {
                 "xs": {
@@ -8803,7 +8803,7 @@
             "low_flow": 129117,
             "high_flow": 940575,
             "network_to_id": "2930531",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930531",
             "metrics": {
                 "xs": {
@@ -8865,7 +8865,7 @@
             "low_flow": 129120,
             "high_flow": 940500,
             "network_to_id": "2930553",
-            "ds_slope": 0.003710000077262521,
+            "ds_slope": 0.00371,
             "ds_slope_source_nwm_id": "2930553",
             "metrics": {
                 "xs": {
@@ -8927,7 +8927,7 @@
             "low_flow": 129120,
             "high_flow": 940500,
             "network_to_id": "2930557",
-            "ds_slope": 0.0013200000394135714,
+            "ds_slope": 0.00132,
             "ds_slope_source_nwm_id": "2930557",
             "metrics": {
                 "xs": {
@@ -8989,7 +8989,7 @@
             "low_flow": 129120,
             "high_flow": 940501,
             "network_to_id": "2931045",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2931045",
             "metrics": {
                 "xs": {
@@ -9051,7 +9051,7 @@
             "low_flow": 129119,
             "high_flow": 940337,
             "network_to_id": "2930907",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930909",
             "metrics": {
                 "xs": {
@@ -9115,7 +9115,7 @@
             "low_flow": 129119,
             "high_flow": 940350,
             "network_to_id": "2930569",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930577",
             "metrics": {
                 "xs": {
@@ -9179,7 +9179,7 @@
             "low_flow": 129117,
             "high_flow": 940292,
             "network_to_id": "2930581",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 6e-05,
             "ds_slope_source_nwm_id": "2930581",
             "metrics": {
                 "xs": {
@@ -9241,7 +9241,7 @@
             "low_flow": 129120,
             "high_flow": 940642,
             "network_to_id": "2930511",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930511",
             "metrics": {
                 "xs": {
@@ -9303,7 +9303,7 @@
             "low_flow": 129118,
             "high_flow": 940347,
             "network_to_id": "2930887",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2931051",
             "metrics": {
                 "xs": {
@@ -9363,7 +9363,7 @@
             "low_flow": 129118,
             "high_flow": 940394,
             "network_to_id": "2931041",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2931041",
             "metrics": {
                 "xs": {
@@ -9425,7 +9425,7 @@
             "low_flow": 129118,
             "high_flow": 940399,
             "network_to_id": "2931043",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2931043",
             "metrics": {
                 "xs": {
@@ -9487,7 +9487,7 @@
             "low_flow": 129119,
             "high_flow": 940384,
             "network_to_id": "2930889",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930905",
             "metrics": {
                 "xs": {
@@ -9551,7 +9551,7 @@
             "low_flow": 129119,
             "high_flow": 940389,
             "network_to_id": "2930559",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930559",
             "metrics": {
                 "xs": {
@@ -9613,7 +9613,7 @@
             "low_flow": 129119,
             "high_flow": 940534,
             "network_to_id": "2930543",
-            "ds_slope": 0.0006200000061653554,
+            "ds_slope": 0.00062,
             "ds_slope_source_nwm_id": "2930875",
             "metrics": {
                 "xs": {
@@ -9677,7 +9677,7 @@
             "low_flow": 129182,
             "high_flow": 932721,
             "network_to_id": "2932885",
-            "ds_slope": 0.0008200000156648457,
+            "ds_slope": 0.00082,
             "ds_slope_source_nwm_id": "2932885",
             "metrics": {
                 "xs": {
@@ -9739,7 +9739,7 @@
             "low_flow": 129182,
             "high_flow": 932719,
             "network_to_id": "2932901",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932901",
             "metrics": {
                 "xs": {
@@ -9801,7 +9801,7 @@
             "low_flow": 129183,
             "high_flow": 932742,
             "network_to_id": "2932905",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932905",
             "metrics": {
                 "xs": {
@@ -9863,7 +9863,7 @@
             "low_flow": 129183,
             "high_flow": 933393,
             "network_to_id": "2930771",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932869",
             "metrics": {
                 "xs": {
@@ -9923,7 +9923,7 @@
             "low_flow": 129183,
             "high_flow": 933407,
             "network_to_id": "2930767",
-            "ds_slope": 0.0006300000241026282,
+            "ds_slope": 0.00063,
             "ds_slope_source_nwm_id": "2930767",
             "metrics": {
                 "xs": {
@@ -9985,7 +9985,7 @@
             "low_flow": 129195,
             "high_flow": 933555,
             "network_to_id": "2938441",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2938445",
             "metrics": {
                 "xs": {
@@ -10049,7 +10049,7 @@
             "low_flow": 129195,
             "high_flow": 933612,
             "network_to_id": "2930603",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930603",
             "metrics": {
                 "xs": {
@@ -10111,7 +10111,7 @@
             "low_flow": 129174,
             "high_flow": 933800,
             "network_to_id": "2930601",
-            "ds_slope": 0.00039000000106170774,
+            "ds_slope": 0.00039,
             "ds_slope_source_nwm_id": "2930601",
             "metrics": {
                 "xs": {
@@ -10173,7 +10173,7 @@
             "low_flow": 129187,
             "high_flow": 933473,
             "network_to_id": "2930749",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930749",
             "metrics": {
                 "xs": {
@@ -10235,7 +10235,7 @@
             "low_flow": 129186,
             "high_flow": 933486,
             "network_to_id": "2930759",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 8e-05,
             "ds_slope_source_nwm_id": "2930759",
             "metrics": {
                 "xs": {
@@ -10297,7 +10297,7 @@
             "low_flow": 129183,
             "high_flow": 933490,
             "network_to_id": "2930761",
-            "ds_slope": 0.005510000046342611,
+            "ds_slope": 0.00551,
             "ds_slope_source_nwm_id": "2930763",
             "metrics": {
                 "xs": {
@@ -10361,7 +10361,7 @@
             "low_flow": 129190,
             "high_flow": 933520,
             "network_to_id": "2938505",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2938505",
             "metrics": {
                 "xs": {
@@ -10423,7 +10423,7 @@
             "low_flow": 129195,
             "high_flow": 933590,
             "network_to_id": "2930607",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930607",
             "metrics": {
                 "xs": {
@@ -10485,7 +10485,7 @@
             "low_flow": 129182,
             "high_flow": 932715,
             "network_to_id": "2932893",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932893",
             "metrics": {
                 "xs": {
@@ -10547,7 +10547,7 @@
             "low_flow": 129183,
             "high_flow": 932725,
             "network_to_id": "2932873",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932873",
             "metrics": {
                 "xs": {
@@ -10609,7 +10609,7 @@
             "low_flow": 129127,
             "high_flow": 939882,
             "network_to_id": "2930593",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00015,
             "ds_slope_source_nwm_id": "2930593",
             "metrics": {
                 "xs": {
@@ -10671,7 +10671,7 @@
             "low_flow": 129195,
             "high_flow": 933535,
             "network_to_id": "2930621",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 4e-05,
             "ds_slope_source_nwm_id": "2930621",
             "metrics": {
                 "xs": {
@@ -10733,7 +10733,7 @@
             "low_flow": 129193,
             "high_flow": 933491,
             "network_to_id": "2930639",
-            "ds_slope": 5.999999848427251e-05,
+            "ds_slope": 6e-05,
             "ds_slope_source_nwm_id": "2930639",
             "metrics": {
                 "xs": {
@@ -10795,7 +10795,7 @@
             "low_flow": 129189,
             "high_flow": 933532,
             "network_to_id": "2938455",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 4e-05,
             "ds_slope_source_nwm_id": "2930679",
             "metrics": {
                 "xs": {
@@ -10859,7 +10859,7 @@
             "low_flow": 129188,
             "high_flow": 933516,
             "network_to_id": "2930705",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930705",
             "metrics": {
                 "xs": {
@@ -10921,7 +10921,7 @@
             "low_flow": 129188,
             "high_flow": 933472,
             "network_to_id": "2938477",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930719",
             "metrics": {
                 "xs": {
@@ -10985,7 +10985,7 @@
             "low_flow": 129188,
             "high_flow": 933475,
             "network_to_id": "2930713",
-            "ds_slope": 9.999999747378752e-05,
+            "ds_slope": 0.0001,
             "ds_slope_source_nwm_id": "2930713",
             "metrics": {
                 "xs": {
@@ -11047,7 +11047,7 @@
             "low_flow": 129188,
             "high_flow": 933465,
             "network_to_id": "2931017",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930981",
             "metrics": {
                 "xs": {
@@ -11111,7 +11111,7 @@
             "low_flow": 129189,
             "high_flow": 933545,
             "network_to_id": "2930651",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930651",
             "metrics": {
                 "xs": {
@@ -11173,7 +11173,7 @@
             "low_flow": 129190,
             "high_flow": 933531,
             "network_to_id": "2938507",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2938507",
             "metrics": {
                 "xs": {
@@ -11235,7 +11235,7 @@
             "low_flow": 129189,
             "high_flow": 933533,
             "network_to_id": "2930649",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930649",
             "metrics": {
                 "xs": {
@@ -11297,7 +11297,7 @@
             "low_flow": 129182,
             "high_flow": 932750,
             "network_to_id": "2932875",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2932881",
             "metrics": {
                 "xs": {
@@ -11361,7 +11361,7 @@
             "low_flow": 129188,
             "high_flow": 933483,
             "network_to_id": "2938485",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930723",
             "metrics": {
                 "xs": {
@@ -11425,7 +11425,7 @@
             "low_flow": 129188,
             "high_flow": 933486,
             "network_to_id": "2930709",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 0.00012,
             "ds_slope_source_nwm_id": "2930709",
             "metrics": {
                 "xs": {
@@ -11487,7 +11487,7 @@
             "low_flow": 129189,
             "high_flow": 933497,
             "network_to_id": "2938461",
-            "ds_slope": 7.999999797903001e-05,
+            "ds_slope": 8e-05,
             "ds_slope_source_nwm_id": "2938461",
             "metrics": {
                 "xs": {
@@ -11549,7 +11549,7 @@
             "low_flow": 129194,
             "high_flow": 933556,
             "network_to_id": "2930625",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00015,
             "ds_slope_source_nwm_id": "2938449",
             "metrics": {
                 "xs": {
@@ -11613,7 +11613,7 @@
             "low_flow": 129128,
             "high_flow": 939924,
             "network_to_id": "2930591",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2930591",
             "metrics": {
                 "xs": {
@@ -11675,7 +11675,7 @@
             "low_flow": 129109,
             "high_flow": 940001,
             "network_to_id": "2938437",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "2938437",
             "metrics": {
                 "xs": {
@@ -11737,7 +11737,7 @@
             "low_flow": 129181,
             "high_flow": 932736,
             "network_to_id": "880776",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880776",
             "metrics": {
                 "xs": {
@@ -11799,7 +11799,7 @@
             "low_flow": 129181,
             "high_flow": 932723,
             "network_to_id": "880624",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880624",
             "metrics": {
                 "xs": {
@@ -11861,7 +11861,7 @@
             "low_flow": 129181,
             "high_flow": 932709,
             "network_to_id": "880820",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880820",
             "metrics": {
                 "xs": {
@@ -11923,7 +11923,7 @@
             "low_flow": 129181,
             "high_flow": 932736,
             "network_to_id": "880784",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880784",
             "metrics": {
                 "xs": {
@@ -11985,7 +11985,7 @@
             "low_flow": 129314,
             "high_flow": 939351,
             "network_to_id": "880548",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880548",
             "metrics": {
                 "xs": {
@@ -12047,7 +12047,7 @@
             "low_flow": 129318,
             "high_flow": 939423,
             "network_to_id": "880596",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880596",
             "metrics": {
                 "xs": {
@@ -12109,7 +12109,7 @@
             "low_flow": 129319,
             "high_flow": 939377,
             "network_to_id": "880630",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880630",
             "metrics": {
                 "xs": {
@@ -12171,7 +12171,7 @@
             "low_flow": 129320,
             "high_flow": 939410,
             "network_to_id": "880654",
-            "ds_slope": 0.0002300000051036477,
+            "ds_slope": 0.00023,
             "ds_slope_source_nwm_id": "880654",
             "metrics": {
                 "xs": {
@@ -12233,7 +12233,7 @@
             "low_flow": 129323,
             "high_flow": 939387,
             "network_to_id": "880640",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880640",
             "metrics": {
                 "xs": {
@@ -12295,7 +12295,7 @@
             "low_flow": 129320,
             "high_flow": 939386,
             "network_to_id": "880662",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880662",
             "metrics": {
                 "xs": {
@@ -12357,7 +12357,7 @@
             "low_flow": 129181,
             "high_flow": 932714,
             "network_to_id": "880604",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880604",
             "metrics": {
                 "xs": {
@@ -12419,7 +12419,7 @@
             "low_flow": 129181,
             "high_flow": 932722,
             "network_to_id": "880786",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880786",
             "metrics": {
                 "xs": {
@@ -12481,7 +12481,7 @@
             "low_flow": 129323,
             "high_flow": 939396,
             "network_to_id": "880644",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880668",
             "metrics": {
                 "xs": {
@@ -12545,7 +12545,7 @@
             "low_flow": 129320,
             "high_flow": 939386,
             "network_to_id": "880818",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880818",
             "metrics": {
                 "xs": {
@@ -12607,7 +12607,7 @@
             "low_flow": 129181,
             "high_flow": 932727,
             "network_to_id": "880614",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880614",
             "metrics": {
                 "xs": {
@@ -12669,7 +12669,7 @@
             "low_flow": 184036,
             "high_flow": 1034814,
             "network_to_id": "880544",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880544",
             "metrics": {
                 "xs": {
@@ -12731,7 +12731,7 @@
             "low_flow": 129463,
             "high_flow": 940855,
             "network_to_id": "880494",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880494",
             "metrics": {
                 "xs": {
@@ -12793,7 +12793,7 @@
             "low_flow": 129314,
             "high_flow": 939356,
             "network_to_id": "880534",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880534",
             "metrics": {
                 "xs": {
@@ -12855,7 +12855,7 @@
             "low_flow": 184040,
             "high_flow": 1034826,
             "network_to_id": "880486",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880486",
             "metrics": {
                 "xs": {
@@ -12917,7 +12917,7 @@
             "low_flow": 129463,
             "high_flow": 940877,
             "network_to_id": "880478",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880484",
             "metrics": {
                 "xs": {
@@ -12981,7 +12981,7 @@
             "low_flow": 184038,
             "high_flow": 1034797,
             "network_to_id": "882688",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880512",
             "metrics": {
                 "xs": {
@@ -13045,7 +13045,7 @@
             "low_flow": 129466,
             "high_flow": 940895,
             "network_to_id": "880816",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880816",
             "metrics": {
                 "xs": {
@@ -13107,7 +13107,7 @@
             "low_flow": 184038,
             "high_flow": 1035097,
             "network_to_id": "880768",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880768",
             "metrics": {
                 "xs": {
@@ -13169,7 +13169,7 @@
             "low_flow": 184038,
             "high_flow": 1035111,
             "network_to_id": "24745881",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "24745881",
             "metrics": {
                 "xs": {
@@ -13231,7 +13231,7 @@
             "low_flow": 184039,
             "high_flow": 1034883,
             "network_to_id": "880536",
-            "ds_slope": 7.000000186963007e-05,
+            "ds_slope": 7e-05,
             "ds_slope_source_nwm_id": "880536",
             "metrics": {
                 "xs": {
@@ -13293,7 +13293,7 @@
             "low_flow": 184039,
             "high_flow": 1034786,
             "network_to_id": "882686",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "882686",
             "metrics": {
                 "xs": {
@@ -13355,7 +13355,7 @@
             "low_flow": 184039,
             "high_flow": 1034813,
             "network_to_id": "880490",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880490",
             "metrics": {
                 "xs": {
@@ -13417,7 +13417,7 @@
             "low_flow": 184074,
             "high_flow": 1023294,
             "network_to_id": "882710",
-            "ds_slope": 4.999999873689376e-05,
+            "ds_slope": 5e-05,
             "ds_slope_source_nwm_id": "882710",
             "metrics": {
                 "xs": {
@@ -13479,7 +13479,7 @@
             "low_flow": 184070,
             "high_flow": 1023228,
             "network_to_id": "880666",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880666",
             "metrics": {
                 "xs": {
@@ -13541,7 +13541,7 @@
             "low_flow": 184037,
             "high_flow": 1022793,
             "network_to_id": "880636",
-            "ds_slope": 0.0033499998971819878,
+            "ds_slope": 0.00335,
             "ds_slope_source_nwm_id": "880636",
             "metrics": {
                 "xs": {
@@ -13603,7 +13603,7 @@
             "low_flow": 184040,
             "high_flow": 1022921,
             "network_to_id": "880606",
-            "ds_slope": 3.9999998989515007e-05,
+            "ds_slope": 4e-05,
             "ds_slope_source_nwm_id": "880606",
             "metrics": {
                 "xs": {
@@ -13665,7 +13665,7 @@
             "low_flow": 184037,
             "high_flow": 1035127,
             "network_to_id": "880814",
-            "ds_slope": 0.00011999999696854502,
+            "ds_slope": 0.00012,
             "ds_slope_source_nwm_id": "880562",
             "metrics": {
                 "xs": {
@@ -13729,7 +13729,7 @@
             "low_flow": 184037,
             "high_flow": 1035116,
             "network_to_id": "880550",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880550",
             "metrics": {
                 "xs": {
@@ -13791,7 +13791,7 @@
             "low_flow": 184070,
             "high_flow": 1023196,
             "network_to_id": "3624763",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624763",
             "metrics": {
                 "xs": {
@@ -13853,7 +13853,7 @@
             "low_flow": 184036,
             "high_flow": 1022773,
             "network_to_id": "880652",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880652",
             "metrics": {
                 "xs": {
@@ -13915,7 +13915,7 @@
             "low_flow": 184077,
             "high_flow": 1023300,
             "network_to_id": "880678",
-            "ds_slope": 2.9999999242136255e-05,
+            "ds_slope": 3e-05,
             "ds_slope_source_nwm_id": "880678",
             "metrics": {
                 "xs": {
@@ -13977,7 +13977,7 @@
             "low_flow": 184037,
             "high_flow": 1022817,
             "network_to_id": "880648",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880648",
             "metrics": {
                 "xs": {
@@ -14039,7 +14039,7 @@
             "low_flow": 184036,
             "high_flow": 1035071,
             "network_to_id": "880580",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880580",
             "metrics": {
                 "xs": {
@@ -14101,7 +14101,7 @@
             "low_flow": 184036,
             "high_flow": 1022774,
             "network_to_id": "880622",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880622",
             "metrics": {
                 "xs": {
@@ -14163,7 +14163,7 @@
             "low_flow": 184037,
             "high_flow": 1022838,
             "network_to_id": "880608",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "880618",
             "metrics": {
                 "xs": {
@@ -14227,7 +14227,7 @@
             "low_flow": 304436,
             "high_flow": 2330751,
             "network_to_id": "3624695",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624695",
             "metrics": {
                 "xs": {
@@ -14289,7 +14289,7 @@
             "low_flow": 304567,
             "high_flow": 2330669,
             "network_to_id": "3624705",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624705",
             "metrics": {
                 "xs": {
@@ -14351,7 +14351,7 @@
             "low_flow": 304568,
             "high_flow": 2330857,
             "network_to_id": "3624701",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "3624701",
             "metrics": {
                 "xs": {

--- a/tests/ras-data/MissFldwy/MissFldwy.conflation.json
+++ b/tests/ras-data/MissFldwy/MissFldwy.conflation.json
@@ -1,112 +1,176 @@
 {
     "reaches": {
-        "5088542": {
+        "5092614": {
             "us_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 361.98,
-                "max_elevation": 406.99,
-                "xs_id": 115.76
+                "reach": "Reach 2",
+                "min_elevation": 279.89,
+                "max_elevation": 397.65,
+                "xs_id": 47.34
             },
             "ds_xs": {
                 "river": "Mississippi",
                 "reach": "Reach 2",
-                "min_elevation": 319.51,
-                "max_elevation": 399.99,
-                "xs_id": 110.4
+                "min_elevation": 274.89,
+                "max_elevation": 400.1,
+                "xs_id": 45.36
             },
             "eclipsed": false,
-            "low_flow": 990,
-            "high_flow": 43125,
-            "network_to_id": "5089894",
+            "low_flow": 313116,
+            "high_flow": 2271710,
+            "network_to_id": "5096814",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 13,
-                        "mean": 485,
-                        "std": 468,
-                        "min": 61,
-                        "25%": 193,
-                        "50%": 351,
-                        "75%": 616,
-                        "max": 1755
+                        "count": 4,
+                        "mean": 162,
+                        "std": 76,
+                        "min": 50,
+                        "25%": 151,
+                        "50%": 192,
+                        "75%": 203,
+                        "max": 216
                     },
                     "thalweg_offset": {
-                        "count": 13,
-                        "mean": 1762,
-                        "std": 1054,
-                        "min": 126,
-                        "25%": 1069,
-                        "50%": 1705,
-                        "75%": 2462,
-                        "max": 3602
+                        "count": 4,
+                        "mean": 173,
+                        "std": 149,
+                        "min": 32,
+                        "25%": 57,
+                        "50%": 157,
+                        "75%": 273,
+                        "max": 344
                     }
                 },
                 "lengths": {
-                    "ras": 35556,
-                    "network": 28540,
-                    "network_to_ras_ratio": 0.8
+                    "ras": 9676,
+                    "network": 10867,
+                    "network_to_ras_ratio": 1.12
                 },
                 "coverage": {
-                    "start": 0.12,
+                    "start": 0.03,
                     "end": 1
                 }
             },
-            "overlapped_reaches": [],
-            "eclipsed_reaches": [
-                "5088588",
-                "5089908",
-                "5088576",
-                "5089894",
-                "5089906"
-            ]
+            "overlapped_reaches": [
+                {
+                    "id": "5096814",
+                    "overlap": 761
+                }
+            ],
+            "eclipsed_reaches": []
         },
-        "5088480": {
+        "5092606": {
             "us_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 366.35,
-                "max_elevation": 411.54,
-                "xs_id": 118.64
+                "reach": "Reach 2",
+                "min_elevation": 285.8,
+                "max_elevation": 385.91,
+                "xs_id": 48.58
             },
             "ds_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 365.62,
-                "max_elevation": 400.12,
-                "xs_id": 117.92
+                "reach": "Reach 2",
+                "min_elevation": 279.89,
+                "max_elevation": 397.65,
+                "xs_id": 47.34
             },
             "eclipsed": false,
-            "low_flow": 363,
-            "high_flow": 11864,
-            "network_to_id": "5088488",
+            "low_flow": 313137,
+            "high_flow": 2271658,
+            "network_to_id": "5092604",
+            "ds_slope": 5.999999848427251e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 3,
-                        "mean": 382,
-                        "std": 231,
-                        "min": 190,
-                        "25%": 254,
-                        "50%": 317,
-                        "75%": 478,
-                        "max": 638
+                        "count": 4,
+                        "mean": 209,
+                        "std": 172,
+                        "min": 50,
+                        "25%": 103,
+                        "50%": 171,
+                        "75%": 277,
+                        "max": 445
                     },
                     "thalweg_offset": {
-                        "count": 3,
-                        "mean": 848,
-                        "std": 827,
-                        "min": 183,
-                        "25%": 385,
-                        "50%": 587,
-                        "75%": 1181,
-                        "max": 1775
+                        "count": 4,
+                        "mean": 221,
+                        "std": 50,
+                        "min": 154,
+                        "25%": 199,
+                        "50%": 231,
+                        "75%": 253,
+                        "max": 267
                     }
                 },
                 "lengths": {
-                    "ras": 9115,
-                    "network": 9860,
-                    "network_to_ras_ratio": 1.08
+                    "ras": 7390,
+                    "network": 8138,
+                    "network_to_ras_ratio": 1.1
+                },
+                "coverage": {
+                    "start": 0.16,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092614",
+                    "overlap": 348
+                }
+            ],
+            "eclipsed_reaches": [
+                "5092604"
+            ]
+        },
+        "5092594": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 287.95,
+                "max_elevation": 386.42,
+                "xs_id": 54.43
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 286.58,
+                "max_elevation": 371.94,
+                "xs_id": 52.15
+            },
+            "eclipsed": false,
+            "low_flow": 311964,
+            "high_flow": 2262053,
+            "network_to_id": "5092598",
+            "ds_slope": 0.00011999999696854502,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 102,
+                        "std": 85,
+                        "min": 32,
+                        "25%": 62,
+                        "50%": 71,
+                        "75%": 102,
+                        "max": 268
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 176,
+                        "std": 123,
+                        "min": 6,
+                        "25%": 120,
+                        "50%": 176,
+                        "75%": 213,
+                        "max": 374
+                    }
+                },
+                "lengths": {
+                    "ras": 12410,
+                    "network": 12611,
+                    "network_to_ras_ratio": 1.02
                 },
                 "coverage": {
                     "start": 0.01,
@@ -115,127 +179,1836 @@
             },
             "overlapped_reaches": [
                 {
-                    "id": "5088524",
-                    "overlap": 133
+                    "id": "5092598",
+                    "overlap": 2475
                 }
             ],
-            "eclipsed_reaches": [
-                "5088490",
-                "5088488"
-            ]
+            "eclipsed_reaches": []
         },
-        "5088488": {
-            "eclipsed": true,
-            "low_flow": 360,
-            "high_flow": 11782,
-            "network_to_id": "5088524"
-        },
-        "5088536": {
+        "5092598": {
             "us_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 361.27,
-                "max_elevation": 420.08,
-                "xs_id": 116.88
+                "reach": "Reach 2",
+                "min_elevation": 286.58,
+                "max_elevation": 371.94,
+                "xs_id": 52.15
             },
             "ds_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 361.98,
-                "max_elevation": 406.99,
-                "xs_id": 115.76
+                "reach": "Reach 2",
+                "min_elevation": 281.43,
+                "max_elevation": 374.53,
+                "xs_id": 49.85
             },
             "eclipsed": false,
-            "low_flow": 986,
-            "high_flow": 44071,
-            "network_to_id": "5088542",
+            "low_flow": 311945,
+            "high_flow": 2261930,
+            "network_to_id": "5092748",
+            "ds_slope": 1.9999999494757503e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 3,
-                        "mean": 173,
-                        "std": 151,
-                        "min": 75,
-                        "25%": 86,
-                        "50%": 97,
-                        "75%": 222,
-                        "max": 347
+                        "count": 9,
+                        "mean": 117,
+                        "std": 40,
+                        "min": 21,
+                        "25%": 110,
+                        "50%": 135,
+                        "75%": 144,
+                        "max": 145
                     },
                     "thalweg_offset": {
-                        "count": 3,
-                        "mean": 186,
-                        "std": 80,
-                        "min": 126,
-                        "25%": 141,
-                        "50%": 156,
-                        "75%": 216,
-                        "max": 277
+                        "count": 9,
+                        "mean": 220,
+                        "std": 68,
+                        "min": 105,
+                        "25%": 220,
+                        "50%": 234,
+                        "75%": 255,
+                        "max": 299
                     }
                 },
                 "lengths": {
-                    "ras": 7652,
-                    "network": 7864,
-                    "network_to_ras_ratio": 1.03
+                    "ras": 14305,
+                    "network": 13929,
+                    "network_to_ras_ratio": 0.97
                 },
                 "coverage": {
-                    "start": 0.22,
+                    "start": 0.17,
                     "end": 1
                 }
             },
             "overlapped_reaches": [
                 {
-                    "id": "5088542",
-                    "overlap": 3433
+                    "id": "5092748",
+                    "overlap": 1938
                 }
             ],
             "eclipsed_reaches": []
         },
-        "5088524": {
+        "5092590": {
             "us_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 365.62,
-                "max_elevation": 400.12,
-                "xs_id": 117.92
+                "reach": "Reach 2",
+                "min_elevation": 289.32,
+                "max_elevation": 381.9,
+                "xs_id": 55.0
             },
             "ds_xs": {
                 "river": "Mississippi",
-                "reach": "Kaskaskia Island",
-                "min_elevation": 361.27,
-                "max_elevation": 420.08,
-                "xs_id": 116.88
+                "reach": "Reach 2",
+                "min_elevation": 287.95,
+                "max_elevation": 386.42,
+                "xs_id": 54.43
             },
             "eclipsed": false,
-            "low_flow": 354,
-            "high_flow": 11400,
-            "network_to_id": "5088536",
+            "low_flow": 311964,
+            "high_flow": 2262109,
+            "network_to_id": "5092594",
+            "ds_slope": 0.0008099999977275729,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 175,
+                        "std": 131,
+                        "min": 82,
+                        "25%": 128,
+                        "50%": 175,
+                        "75%": 221,
+                        "max": 268
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 513,
+                        "std": 196,
+                        "min": 374,
+                        "25%": 444,
+                        "50%": 513,
+                        "75%": 582,
+                        "max": 652
+                    }
+                },
+                "lengths": {
+                    "ras": 2809,
+                    "network": 2968,
+                    "network_to_ras_ratio": 1.06
+                },
+                "coverage": {
+                    "start": 0.25,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092594",
+                    "overlap": 65
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092586": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 277.82,
+                "max_elevation": 379.98,
+                "xs_id": 60.52
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 289.32,
+                "max_elevation": 381.9,
+                "xs_id": 55.0
+            },
+            "eclipsed": false,
+            "low_flow": 311953,
+            "high_flow": 2262028,
+            "network_to_id": "5092590",
+            "ds_slope": 9.000000136438757e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 12,
+                        "mean": 107,
+                        "std": 72,
+                        "min": 15,
+                        "25%": 54,
+                        "50%": 84,
+                        "75%": 171,
+                        "max": 225
+                    },
+                    "thalweg_offset": {
+                        "count": 12,
+                        "mean": 228,
+                        "std": 180,
+                        "min": 17,
+                        "25%": 109,
+                        "50%": 184,
+                        "75%": 272,
+                        "max": 652
+                    }
+                },
+                "lengths": {
+                    "ras": 28174,
+                    "network": 27440,
+                    "network_to_ras_ratio": 0.97
+                },
+                "coverage": {
+                    "start": 0.01,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092590",
+                    "overlap": 967
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092582": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 296.85,
+                "max_elevation": 378.78,
+                "xs_id": 61.83
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 277.82,
+                "max_elevation": 379.98,
+                "xs_id": 60.52
+            },
+            "eclipsed": false,
+            "low_flow": 312044,
+            "high_flow": 2263096,
+            "network_to_id": "5092586",
+            "ds_slope": 2.9999999242136255e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
                         "count": 3,
-                        "mean": 440,
-                        "std": 298,
-                        "min": 97,
-                        "25%": 341,
-                        "50%": 585,
-                        "75%": 611,
-                        "max": 638
+                        "mean": 14,
+                        "std": 10,
+                        "min": 4,
+                        "25%": 10,
+                        "50%": 16,
+                        "75%": 20,
+                        "max": 23
                     },
                     "thalweg_offset": {
                         "count": 3,
-                        "mean": 931,
-                        "std": 812,
-                        "min": 156,
-                        "25%": 509,
-                        "50%": 861,
-                        "75%": 1318,
-                        "max": 1775
+                        "mean": 214,
+                        "std": 63,
+                        "min": 177,
+                        "25%": 177,
+                        "50%": 178,
+                        "75%": 232,
+                        "max": 286
                     }
                 },
                 "lengths": {
-                    "ras": 9008,
-                    "network": 8861,
+                    "ras": 6204,
+                    "network": 6274,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.13,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092586",
+                    "overlap": 337
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092552": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 289.11,
+                "max_elevation": 380.06,
+                "xs_id": 68.66
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 299.46,
+                "max_elevation": 381.52,
+                "xs_id": 68.09
+            },
+            "eclipsed": false,
+            "low_flow": 312063,
+            "high_flow": 2263113,
+            "network_to_id": "5092562",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 92,
+                        "std": 17,
+                        "min": 80,
+                        "25%": 86,
+                        "50%": 92,
+                        "75%": 98,
+                        "max": 104
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 191,
+                        "std": 64,
+                        "min": 146,
+                        "25%": 169,
+                        "50%": 191,
+                        "75%": 214,
+                        "max": 237
+                    }
+                },
+                "lengths": {
+                    "ras": 2969,
+                    "network": 2972,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.47,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092562",
+                    "overlap": 1449
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092542": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 302.66,
+                "max_elevation": 386.33,
+                "xs_id": 69.75
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 289.11,
+                "max_elevation": 380.06,
+                "xs_id": 68.66
+            },
+            "eclipsed": false,
+            "low_flow": 312049,
+            "high_flow": 2262999,
+            "network_to_id": "5092552",
+            "ds_slope": 7.999999797903001e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 78,
+                        "std": 43,
+                        "min": 34,
+                        "25%": 57,
+                        "50%": 80,
+                        "75%": 100,
+                        "max": 120
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 189,
+                        "std": 111,
+                        "min": 62,
+                        "25%": 150,
+                        "50%": 237,
+                        "75%": 253,
+                        "max": 268
+                    }
+                },
+                "lengths": {
+                    "ras": 5773,
+                    "network": 5815,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.37,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092552",
+                    "overlap": 1346
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5090014": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 286.95,
+                "max_elevation": 387.38,
+                "xs_id": 70.27
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 302.66,
+                "max_elevation": 386.33,
+                "xs_id": 69.75
+            },
+            "eclipsed": false,
+            "low_flow": 312055,
+            "high_flow": 2263142,
+            "network_to_id": "5092542",
+            "ds_slope": 0.00013000000035390258,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 98,
+                        "std": 32,
+                        "min": 76,
+                        "25%": 87,
+                        "50%": 98,
+                        "75%": 109,
+                        "max": 120
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 147,
+                        "std": 121,
+                        "min": 62,
+                        "25%": 105,
+                        "50%": 147,
+                        "75%": 190,
+                        "max": 233
+                    }
+                },
+                "lengths": {
+                    "ras": 2748,
+                    "network": 2899,
+                    "network_to_ras_ratio": 1.05
+                },
+                "coverage": {
+                    "start": 0.77,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092542",
+                    "overlap": 2664
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5090010": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 297.2,
+                "max_elevation": 395.98,
+                "xs_id": 71.78
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 286.95,
+                "max_elevation": 387.38,
+                "xs_id": 70.27
+            },
+            "eclipsed": false,
+            "low_flow": 312054,
+            "high_flow": 2263096,
+            "network_to_id": "5090014",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 55,
+                        "std": 18,
+                        "min": 32,
+                        "25%": 49,
+                        "50%": 55,
+                        "75%": 61,
+                        "max": 76
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 137,
+                        "std": 100,
+                        "min": 7,
+                        "25%": 87,
+                        "50%": 154,
+                        "75%": 203,
+                        "max": 233
+                    }
+                },
+                "lengths": {
+                    "ras": 8067,
+                    "network": 8175,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5090014",
+                    "overlap": 796
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5090004": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 305.12,
+                "max_elevation": 388.18,
+                "xs_id": 72.31
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 297.2,
+                "max_elevation": 395.98,
+                "xs_id": 71.78
+            },
+            "eclipsed": false,
+            "low_flow": 312061,
+            "high_flow": 2263132,
+            "network_to_id": "5090010",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 45,
+                        "std": 15,
+                        "min": 35,
+                        "25%": 40,
+                        "50%": 45,
+                        "75%": 50,
+                        "max": 56
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 115,
+                        "std": 112,
+                        "min": 36,
+                        "25%": 75,
+                        "50%": 115,
+                        "75%": 154,
+                        "max": 193
+                    }
+                },
+                "lengths": {
+                    "ras": 2843,
+                    "network": 2866,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.53,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5090010",
+                    "overlap": 648
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5090000": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 302.05,
+                "max_elevation": 392.26,
+                "xs_id": 73.56
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 305.12,
+                "max_elevation": 388.18,
+                "xs_id": 72.31
+            },
+            "eclipsed": false,
+            "low_flow": 312063,
+            "high_flow": 2263172,
+            "network_to_id": "5090004",
+            "ds_slope": 0.000539999979082495,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 37,
+                        "std": 2,
+                        "min": 35,
+                        "25%": 36,
+                        "50%": 38,
+                        "75%": 39,
+                        "max": 39
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 154,
+                        "std": 103,
+                        "min": 36,
+                        "25%": 120,
+                        "50%": 205,
+                        "75%": 214,
+                        "max": 222
+                    }
+                },
+                "lengths": {
+                    "ras": 6379,
+                    "network": 6447,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.07,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5090004",
+                    "overlap": 2525
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089998": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 303.92,
+                "max_elevation": 389.02,
+                "xs_id": 74.89
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 302.05,
+                "max_elevation": 392.26,
+                "xs_id": 73.56
+            },
+            "eclipsed": false,
+            "low_flow": 312063,
+            "high_flow": 2263144,
+            "network_to_id": "5090000",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 27,
+                        "std": 11,
+                        "min": 20,
+                        "25%": 21,
+                        "50%": 22,
+                        "75%": 31,
+                        "max": 39
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 133,
+                        "std": 110,
+                        "min": 10,
+                        "25%": 89,
+                        "50%": 168,
+                        "75%": 195,
+                        "max": 222
+                    }
+                },
+                "lengths": {
+                    "ras": 7210,
+                    "network": 7215,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5090000",
+                    "overlap": 314
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089984": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 297.11,
+                "max_elevation": 380.04,
+                "xs_id": 77.21
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 298.22,
+                "max_elevation": 389.7,
+                "xs_id": 76.2
+            },
+            "eclipsed": false,
+            "low_flow": 311261,
+            "high_flow": 2276430,
+            "network_to_id": "5089986",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 78,
+                        "std": 63,
+                        "min": 10,
+                        "25%": 49,
+                        "50%": 87,
+                        "75%": 112,
+                        "max": 136
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 191,
+                        "std": 50,
+                        "min": 133,
+                        "25%": 176,
+                        "50%": 219,
+                        "75%": 220,
+                        "max": 222
+                    }
+                },
+                "lengths": {
+                    "ras": 5018,
+                    "network": 5010,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.47,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089986",
+                    "overlap": 1086
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089978": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 300.31,
+                "max_elevation": 390.84,
+                "xs_id": 81.09
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 297.11,
+                "max_elevation": 380.04,
+                "xs_id": 77.21
+            },
+            "eclipsed": false,
+            "low_flow": 311267,
+            "high_flow": 2276412,
+            "network_to_id": "5089984",
+            "ds_slope": 3.9999998989515007e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 10,
+                        "mean": 228,
+                        "std": 182,
+                        "min": 8,
+                        "25%": 110,
+                        "50%": 176,
+                        "75%": 258,
+                        "max": 557
+                    },
+                    "thalweg_offset": {
+                        "count": 10,
+                        "mean": 309,
+                        "std": 302,
+                        "min": 49,
+                        "25%": 84,
+                        "50%": 224,
+                        "75%": 433,
+                        "max": 1036
+                    }
+                },
+                "lengths": {
+                    "ras": 20960,
+                    "network": 21216,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089984",
+                    "overlap": 3500
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092698": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 269.488,
+                "max_elevation": 341.5351,
+                "xs_id": 30.82
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 275.459,
+                "max_elevation": 342.95,
+                "xs_id": 28.57
+            },
+            "eclipsed": false,
+            "low_flow": 313129,
+            "high_flow": 2272768,
+            "network_to_id": "5092712",
+            "ds_slope": 0.0001500000071246177,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 5,
+                        "mean": 46,
+                        "std": 26,
+                        "min": 3,
+                        "25%": 46,
+                        "50%": 50,
+                        "75%": 60,
+                        "max": 71
+                    },
+                    "thalweg_offset": {
+                        "count": 5,
+                        "mean": 147,
+                        "std": 119,
+                        "min": 16,
+                        "25%": 74,
+                        "50%": 126,
+                        "75%": 191,
+                        "max": 326
+                    }
+                },
+                "lengths": {
+                    "ras": 12389,
+                    "network": 12442,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.03,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092712",
+                    "overlap": 1660
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092676": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 278.543,
+                "max_elevation": 344.488,
+                "xs_id": 34.69
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 269.488,
+                "max_elevation": 341.5351,
+                "xs_id": 30.82
+            },
+            "eclipsed": false,
+            "low_flow": 313132,
+            "high_flow": 2272717,
+            "network_to_id": "5092698",
+            "ds_slope": 7.999999797903001e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 10,
+                        "mean": 26,
+                        "std": 19,
+                        "min": 2,
+                        "25%": 14,
+                        "50%": 25,
+                        "75%": 32,
+                        "max": 60
+                    },
+                    "thalweg_offset": {
+                        "count": 10,
+                        "mean": 163,
+                        "std": 104,
+                        "min": 10,
+                        "25%": 70,
+                        "50%": 173,
+                        "75%": 234,
+                        "max": 326
+                    }
+                },
+                "lengths": {
+                    "ras": 20591,
+                    "network": 20578,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092698",
+                    "overlap": 327
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092634": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 285.86,
+                "max_elevation": 361.22,
+                "xs_id": 39.02
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 287.73,
+                "max_elevation": 354.3309,
+                "xs_id": 38.58
+            },
+            "eclipsed": false,
+            "low_flow": 313317,
+            "high_flow": 2273497,
+            "network_to_id": "5092646",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 49,
+                        "std": 17,
+                        "min": 37,
+                        "25%": 43,
+                        "50%": 49,
+                        "75%": 55,
+                        "max": 61
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 114,
+                        "std": 136,
+                        "min": 18,
+                        "25%": 66,
+                        "50%": 114,
+                        "75%": 162,
+                        "max": 210
+                    }
+                },
+                "lengths": {
+                    "ras": 2393,
+                    "network": 2466,
+                    "network_to_ras_ratio": 1.03
+                },
+                "coverage": {
+                    "start": 0.49,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092646",
+                    "overlap": 53
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092630": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 284.71,
+                "max_elevation": 367.99,
+                "xs_id": 41.1
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 285.86,
+                "max_elevation": 361.22,
+                "xs_id": 39.02
+            },
+            "eclipsed": false,
+            "low_flow": 313319,
+            "high_flow": 2273521,
+            "network_to_id": "5092634",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 5,
+                        "mean": 65,
+                        "std": 32,
+                        "min": 27,
+                        "25%": 37,
+                        "50%": 72,
+                        "75%": 94,
+                        "max": 96
+                    },
+                    "thalweg_offset": {
+                        "count": 5,
+                        "mean": 141,
+                        "std": 98,
+                        "min": 18,
+                        "25%": 116,
+                        "50%": 117,
+                        "75%": 165,
+                        "max": 288
+                    }
+                },
+                "lengths": {
+                    "ras": 10891,
+                    "network": 10760,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.21,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092634",
+                    "overlap": 2320
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089946": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 306.03,
+                "max_elevation": 401.3,
+                "xs_id": 87.94
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 290.92,
+                "max_elevation": 389.66,
+                "xs_id": 84.96
+            },
+            "eclipsed": false,
+            "low_flow": 311298,
+            "high_flow": 2277330,
+            "network_to_id": "5096766",
+            "ds_slope": 0.00026000000070780516,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 7,
+                        "mean": 30,
+                        "std": 23,
+                        "min": 4,
+                        "25%": 10,
+                        "50%": 30,
+                        "75%": 45,
+                        "max": 66
+                    },
+                    "thalweg_offset": {
+                        "count": 7,
+                        "mean": 209,
+                        "std": 112,
+                        "min": 39,
+                        "25%": 139,
+                        "50%": 243,
+                        "75%": 269,
+                        "max": 363
+                    }
+                },
+                "lengths": {
+                    "ras": 15159,
+                    "network": 15243,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.06,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5096766",
+                    "overlap": 938
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5096766": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 290.92,
+                "max_elevation": 389.66,
+                "xs_id": 84.96
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 292.77,
+                "max_elevation": 400.4,
+                "xs_id": 83.97
+            },
+            "eclipsed": false,
+            "low_flow": 311308,
+            "high_flow": 2277306,
+            "network_to_id": "5089952",
+            "ds_slope": 4.999999873689376e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 83,
+                        "std": 111,
+                        "min": 10,
+                        "25%": 20,
+                        "50%": 30,
+                        "75%": 120,
+                        "max": 210
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 355,
+                        "std": 126,
+                        "min": 265,
+                        "25%": 284,
+                        "50%": 302,
+                        "75%": 400,
+                        "max": 499
+                    }
+                },
+                "lengths": {
+                    "ras": 5128,
+                    "network": 4846,
+                    "network_to_ras_ratio": 0.95
+                },
+                "coverage": {
+                    "start": 0.27,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089952",
+                    "overlap": 2369
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089952": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 292.77,
+                "max_elevation": 400.4,
+                "xs_id": 83.97
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 295.95,
+                "max_elevation": 400.43,
+                "xs_id": 82.48
+            },
+            "eclipsed": false,
+            "low_flow": 311299,
+            "high_flow": 2277231,
+            "network_to_id": "5089960",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 111,
+                        "std": 73,
+                        "min": 35,
+                        "25%": 82,
+                        "50%": 100,
+                        "75%": 129,
+                        "max": 210
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 161,
+                        "std": 96,
+                        "min": 89,
+                        "25%": 107,
+                        "50%": 126,
+                        "75%": 181,
+                        "max": 302
+                    }
+                },
+                "lengths": {
+                    "ras": 8045,
+                    "network": 7935,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.28,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089970",
+                    "overlap": 354
+                }
+            ],
+            "eclipsed_reaches": [
+                "5089960"
+            ]
+        },
+        "5092562": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 299.46,
+                "max_elevation": 381.52,
+                "xs_id": 68.09
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 298.71,
+                "max_elevation": 380.4,
+                "xs_id": 66.98
+            },
+            "eclipsed": false,
+            "low_flow": 312059,
+            "high_flow": 2263257,
+            "network_to_id": "5092566",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 42,
+                        "std": 55,
+                        "min": 3,
+                        "25%": 11,
+                        "50%": 19,
+                        "75%": 62,
+                        "max": 104
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 158,
+                        "std": 59,
+                        "min": 106,
+                        "25%": 126,
+                        "50%": 146,
+                        "75%": 184,
+                        "max": 222
+                    }
+                },
+                "lengths": {
+                    "ras": 5950,
+                    "network": 5971,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.23,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092566",
+                    "overlap": 1210
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5096814": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 274.89,
+                "max_elevation": 400.1,
+                "xs_id": 45.36
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 277.43,
+                "max_elevation": 400.0,
+                "xs_id": 44.29
+            },
+            "eclipsed": false,
+            "low_flow": 313362,
+            "high_flow": 2273460,
+            "network_to_id": "5092616",
+            "ds_slope": 0.0016899999463930726,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 130,
+                        "std": 60,
+                        "min": 66,
+                        "25%": 103,
+                        "50%": 140,
+                        "75%": 162,
+                        "max": 185
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 112,
+                        "std": 133,
+                        "min": 32,
+                        "25%": 35,
+                        "50%": 39,
+                        "75%": 152,
+                        "max": 265
+                    }
+                },
+                "lengths": {
+                    "ras": 5807,
+                    "network": 5609,
+                    "network_to_ras_ratio": 0.97
+                },
+                "coverage": {
+                    "start": 0.13,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092616",
+                    "overlap": 635
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092748": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 281.43,
+                "max_elevation": 374.53,
+                "xs_id": 49.85
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 285.8,
+                "max_elevation": 385.91,
+                "xs_id": 48.58
+            },
+            "eclipsed": false,
+            "low_flow": 311960,
+            "high_flow": 2262203,
+            "network_to_id": "5092602",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 309,
+                        "std": 173,
+                        "min": 115,
+                        "25%": 241,
+                        "50%": 367,
+                        "75%": 406,
+                        "max": 445
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 237,
+                        "std": 75,
+                        "min": 154,
+                        "25%": 206,
+                        "50%": 258,
+                        "75%": 278,
+                        "max": 299
+                    }
+                },
+                "lengths": {
+                    "ras": 7080,
+                    "network": 7892,
+                    "network_to_ras_ratio": 1.11
+                },
+                "coverage": {
+                    "start": 0.25,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092606",
+                    "overlap": 1185
+                }
+            ],
+            "eclipsed_reaches": [
+                "5092602"
+            ]
+        },
+        "5092566": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 298.71,
+                "max_elevation": 380.4,
+                "xs_id": 66.98
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 298.52,
+                "max_elevation": 380.14,
+                "xs_id": 66.3
+            },
+            "eclipsed": false,
+            "low_flow": 312059,
+            "high_flow": 2263257,
+            "network_to_id": "5092568",
+            "ds_slope": 0.0002099999983329326,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 12,
+                        "std": 13,
+                        "min": 3,
+                        "25%": 7,
+                        "50%": 12,
+                        "75%": 17,
+                        "max": 21
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 75,
+                        "std": 43,
+                        "min": 45,
+                        "25%": 60,
+                        "50%": 75,
+                        "75%": 91,
+                        "max": 106
+                    }
+                },
+                "lengths": {
+                    "ras": 3028,
+                    "network": 3038,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.4,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092568",
+                    "overlap": 1213
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092568": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 298.52,
+                "max_elevation": 380.14,
+                "xs_id": 66.3
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 297.35,
+                "max_elevation": 385.17,
+                "xs_id": 65.84
+            },
+            "eclipsed": false,
+            "low_flow": 312059,
+            "high_flow": 2263204,
+            "network_to_id": "5092572",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 42,
+                        "std": 29,
+                        "min": 21,
+                        "25%": 32,
+                        "50%": 42,
+                        "75%": 52,
+                        "max": 63
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 216,
+                        "std": 241,
+                        "min": 45,
+                        "25%": 130,
+                        "50%": 216,
+                        "75%": 301,
+                        "max": 386
+                    }
+                },
+                "lengths": {
+                    "ras": 3120,
+                    "network": 3052,
                     "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.46,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092572",
+                    "overlap": 1652
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092572": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 297.35,
+                "max_elevation": 385.17,
+                "xs_id": 65.84
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 296.85,
+                "max_elevation": 378.78,
+                "xs_id": 61.83
+            },
+            "eclipsed": false,
+            "low_flow": 312048,
+            "high_flow": 2263183,
+            "network_to_id": "5092582",
+            "ds_slope": 0.00014000000373926014,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 8,
+                        "mean": 93,
+                        "std": 80,
+                        "min": 4,
+                        "25%": 45,
+                        "50%": 63,
+                        "75%": 123,
+                        "max": 244
+                    },
+                    "thalweg_offset": {
+                        "count": 8,
+                        "mean": 239,
+                        "std": 80,
+                        "min": 125,
+                        "25%": 187,
+                        "50%": 233,
+                        "75%": 277,
+                        "max": 386
+                    }
+                },
+                "lengths": {
+                    "ras": 21093,
+                    "network": 21102,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092582",
+                    "overlap": 904
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089986": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 298.22,
+                "max_elevation": 389.7,
+                "xs_id": 76.2
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 303.92,
+                "max_elevation": 389.02,
+                "xs_id": 74.89
+            },
+            "eclipsed": false,
+            "low_flow": 311263,
+            "high_flow": 2276431,
+            "network_to_id": "5089990",
+            "ds_slope": 0.0002500000118743628,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 64,
+                        "std": 36,
+                        "min": 22,
+                        "25%": 52,
+                        "50%": 82,
+                        "75%": 85,
+                        "max": 87
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 200,
+                        "std": 180,
+                        "min": 10,
+                        "25%": 116,
+                        "50%": 222,
+                        "75%": 295,
+                        "max": 369
+                    }
+                },
+                "lengths": {
+                    "ras": 6485,
+                    "network": 6537,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.26,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089998",
+                    "overlap": 634
+                }
+            ],
+            "eclipsed_reaches": [
+                "5089990"
+            ]
+        },
+        "5089970": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 295.95,
+                "max_elevation": 400.43,
+                "xs_id": 82.48
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 300.31,
+                "max_elevation": 390.84,
+                "xs_id": 81.09
+            },
+            "eclipsed": false,
+            "low_flow": 311296,
+            "high_flow": 2277122,
+            "network_to_id": "5089978",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 62,
+                        "std": 48,
+                        "min": 7,
+                        "25%": 29,
+                        "50%": 67,
+                        "75%": 100,
+                        "max": 107
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 177,
+                        "std": 104,
+                        "min": 89,
+                        "25%": 108,
+                        "50%": 148,
+                        "75%": 217,
+                        "max": 322
+                    }
+                },
+                "lengths": {
+                    "ras": 7420,
+                    "network": 7518,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.06,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089978",
+                    "overlap": 1449
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089926": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 306.01,
+                "max_elevation": 399.91,
+                "xs_id": 91.32
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 307.68,
+                "max_elevation": 403.64,
+                "xs_id": 89.55
+            },
+            "eclipsed": false,
+            "low_flow": 311300,
+            "high_flow": 2277464,
+            "network_to_id": "5089932",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 41,
+                        "std": 33,
+                        "min": 8,
+                        "25%": 17,
+                        "50%": 40,
+                        "75%": 64,
+                        "max": 77
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 184,
+                        "std": 174,
+                        "min": 4,
+                        "25%": 56,
+                        "50%": 180,
+                        "75%": 308,
+                        "max": 374
+                    }
+                },
+                "lengths": {
+                    "ras": 8403,
+                    "network": 8420,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.05,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089938",
+                    "overlap": 131
+                }
+            ],
+            "eclipsed_reaches": [
+                "5089932"
+            ]
+        },
+        "5089938": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 307.68,
+                "max_elevation": 403.64,
+                "xs_id": 89.55
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 306.03,
+                "max_elevation": 401.3,
+                "xs_id": 87.94
+            },
+            "eclipsed": false,
+            "low_flow": 311295,
+            "high_flow": 2277301,
+            "network_to_id": "5089946",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 80,
+                        "std": 52,
+                        "min": 20,
+                        "25%": 54,
+                        "50%": 77,
+                        "75%": 102,
+                        "max": 145
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 121,
+                        "std": 97,
+                        "min": 4,
+                        "25%": 62,
+                        "50%": 132,
+                        "75%": 191,
+                        "max": 217
+                    }
+                },
+                "lengths": {
+                    "ras": 8457,
+                    "network": 8553,
+                    "network_to_ras_ratio": 1.01
                 },
                 "coverage": {
                     "start": 0.02,
@@ -244,8 +2017,1538 @@
             },
             "overlapped_reaches": [
                 {
-                    "id": "5088536",
-                    "overlap": 1272
+                    "id": "5089946",
+                    "overlap": 941
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092646": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 287.73,
+                "max_elevation": 354.3309,
+                "xs_id": 38.58
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 278.543,
+                "max_elevation": 344.488,
+                "xs_id": 34.69
+            },
+            "eclipsed": false,
+            "low_flow": 313251,
+            "high_flow": 2273215,
+            "network_to_id": "5092652",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 9,
+                        "mean": 33,
+                        "std": 32,
+                        "min": 2,
+                        "25%": 4,
+                        "50%": 27,
+                        "75%": 41,
+                        "max": 100
+                    },
+                    "thalweg_offset": {
+                        "count": 9,
+                        "mean": 242,
+                        "std": 159,
+                        "min": 56,
+                        "25%": 88,
+                        "50%": 210,
+                        "75%": 350,
+                        "max": 458
+                    }
+                },
+                "lengths": {
+                    "ras": 20823,
+                    "network": 20962,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.0,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092676",
+                    "overlap": 1742
+                }
+            ],
+            "eclipsed_reaches": [
+                "5092652"
+            ]
+        },
+        "5092622": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 273.06,
+                "max_elevation": 360.15,
+                "xs_id": 43.2
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 284.71,
+                "max_elevation": 367.99,
+                "xs_id": 41.1
+            },
+            "eclipsed": false,
+            "low_flow": 313345,
+            "high_flow": 2273522,
+            "network_to_id": "5092626",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 5,
+                        "mean": 105,
+                        "std": 56,
+                        "min": 57,
+                        "25%": 70,
+                        "50%": 72,
+                        "75%": 144,
+                        "max": 184
+                    },
+                    "thalweg_offset": {
+                        "count": 5,
+                        "mean": 152,
+                        "std": 88,
+                        "min": 75,
+                        "25%": 88,
+                        "50%": 116,
+                        "75%": 197,
+                        "max": 285
+                    }
+                },
+                "lengths": {
+                    "ras": 11279,
+                    "network": 11468,
+                    "network_to_ras_ratio": 1.02
+                },
+                "coverage": {
+                    "start": 0.12,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092630",
+                    "overlap": 2266
+                }
+            ],
+            "eclipsed_reaches": [
+                "5092626"
+            ]
+        },
+        "5092616": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 277.43,
+                "max_elevation": 400.0,
+                "xs_id": 44.29
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 273.06,
+                "max_elevation": 360.15,
+                "xs_id": 43.2
+            },
+            "eclipsed": false,
+            "low_flow": 313362,
+            "high_flow": 2273502,
+            "network_to_id": "5092622",
+            "ds_slope": 9.999999747378752e-06,
+            "gage": "07022000",
+            "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07022000&legacy=1",
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 158,
+                        "std": 16,
+                        "min": 140,
+                        "25%": 149,
+                        "50%": 157,
+                        "75%": 164,
+                        "max": 184
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 91,
+                        "std": 90,
+                        "min": 19,
+                        "25%": 37,
+                        "50%": 73,
+                        "75%": 87,
+                        "max": 265
+                    }
+                },
+                "lengths": {
+                    "ras": 5448,
+                    "network": 5765,
+                    "network_to_ras_ratio": 1.06
+                },
+                "coverage": {
+                    "start": 0.12,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092622",
+                    "overlap": 1103
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092706": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 236.22,
+                "max_elevation": 337.72,
+                "xs_id": 6.25
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 254.97,
+                "max_elevation": 339.98,
+                "xs_id": 5.11
+            },
+            "eclipsed": false,
+            "low_flow": 313333,
+            "high_flow": 2242929,
+            "network_to_id": "5093440",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 77,
+                        "std": 90,
+                        "min": 24,
+                        "25%": 25,
+                        "50%": 27,
+                        "75%": 104,
+                        "max": 182
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 1646,
+                        "std": 1434,
+                        "min": 41,
+                        "25%": 1070,
+                        "50%": 2099,
+                        "75%": 2449,
+                        "max": 2799
+                    }
+                },
+                "lengths": {
+                    "ras": 5995,
+                    "network": 6023,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.13,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5093440",
+                    "overlap": 2068
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5093440": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 254.97,
+                "max_elevation": 339.98,
+                "xs_id": 5.11
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 260.61,
+                "max_elevation": 336.55,
+                "xs_id": 4.58
+            },
+            "eclipsed": false,
+            "low_flow": 313329,
+            "high_flow": 2242849,
+            "network_to_id": "5093450",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 103,
+                        "std": 112,
+                        "min": 23,
+                        "25%": 63,
+                        "50%": 103,
+                        "75%": 142,
+                        "max": 182
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 418,
+                        "std": 533,
+                        "min": 41,
+                        "25%": 229,
+                        "50%": 418,
+                        "75%": 606,
+                        "max": 795
+                    }
+                },
+                "lengths": {
+                    "ras": 3276,
+                    "network": 3253,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.48,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5093450",
+                    "overlap": 992
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092674": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 260.86,
+                "max_elevation": 338.911,
+                "xs_id": 11.25
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 257.6122,
+                "max_elevation": 338.911,
+                "xs_id": 9.6
+            },
+            "eclipsed": false,
+            "low_flow": 313358,
+            "high_flow": 2243140,
+            "network_to_id": "5092686",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 37,
+                        "std": 30,
+                        "min": 10,
+                        "25%": 18,
+                        "50%": 29,
+                        "75%": 47,
+                        "max": 79
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 488,
+                        "std": 274,
+                        "min": 91,
+                        "25%": 414,
+                        "50%": 592,
+                        "75%": 666,
+                        "max": 676
+                    }
+                },
+                "lengths": {
+                    "ras": 8491,
+                    "network": 8629,
+                    "network_to_ras_ratio": 1.02
+                },
+                "coverage": {
+                    "start": 0.12,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092686",
+                    "overlap": 1574
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092696": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 255.32,
+                "max_elevation": 339.26,
+                "xs_id": 8.23
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 256.08,
+                "max_elevation": 341.92,
+                "xs_id": 7.517
+            },
+            "eclipsed": false,
+            "low_flow": 313346,
+            "high_flow": 2242953,
+            "network_to_id": "5092702",
+            "ds_slope": 7.000000186963007e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 143,
+                        "std": 33,
+                        "min": 121,
+                        "25%": 124,
+                        "50%": 126,
+                        "75%": 153,
+                        "max": 180
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 719,
+                        "std": 924,
+                        "min": 131,
+                        "25%": 186,
+                        "50%": 242,
+                        "75%": 1013,
+                        "max": 1784
+                    }
+                },
+                "lengths": {
+                    "ras": 3088,
+                    "network": 3118,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.58,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092702",
+                    "overlap": 146
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092686": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 257.6122,
+                "max_elevation": 338.911,
+                "xs_id": 9.6
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 255.32,
+                "max_elevation": 339.26,
+                "xs_id": 8.23
+            },
+            "eclipsed": false,
+            "low_flow": 313356,
+            "high_flow": 2243136,
+            "network_to_id": "5092696",
+            "ds_slope": 0.00016999999934341758,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 134,
+                        "std": 51,
+                        "min": 79,
+                        "25%": 111,
+                        "50%": 142,
+                        "75%": 161,
+                        "max": 180
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 375,
+                        "std": 141,
+                        "min": 242,
+                        "25%": 301,
+                        "50%": 360,
+                        "75%": 441,
+                        "max": 522
+                    }
+                },
+                "lengths": {
+                    "ras": 8937,
+                    "network": 8233,
+                    "network_to_ras_ratio": 0.92
+                },
+                "coverage": {
+                    "start": 0.28,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092696",
+                    "overlap": 4104
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092702": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 256.08,
+                "max_elevation": 341.92,
+                "xs_id": 7.517
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 236.22,
+                "max_elevation": 337.72,
+                "xs_id": 6.25
+            },
+            "eclipsed": false,
+            "low_flow": 313337,
+            "high_flow": 2243004,
+            "network_to_id": "5092706",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 116,
+                        "std": 47,
+                        "min": 24,
+                        "25%": 122,
+                        "50%": 126,
+                        "75%": 144,
+                        "max": 151
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 2125,
+                        "std": 513,
+                        "min": 1781,
+                        "25%": 1788,
+                        "50%": 1805,
+                        "75%": 2535,
+                        "max": 2799
+                    }
+                },
+                "lengths": {
+                    "ras": 6966,
+                    "network": 6593,
+                    "network_to_ras_ratio": 0.95
+                },
+                "coverage": {
+                    "start": 0.02,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092706",
+                    "overlap": 594
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092660": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 248.458,
+                "max_elevation": 337.9269,
+                "xs_id": 12.2
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 260.86,
+                "max_elevation": 338.911,
+                "xs_id": 11.25
+            },
+            "eclipsed": false,
+            "low_flow": 313372,
+            "high_flow": 2243130,
+            "network_to_id": "5092674",
+            "ds_slope": 7.999999797903001e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 16,
+                        "std": 11,
+                        "min": 8,
+                        "25%": 9,
+                        "50%": 10,
+                        "75%": 20,
+                        "max": 29
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 164,
+                        "std": 104,
+                        "min": 91,
+                        "25%": 104,
+                        "50%": 117,
+                        "75%": 200,
+                        "max": 283
+                    }
+                },
+                "lengths": {
+                    "ras": 5467,
+                    "network": 5490,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.35,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092674",
+                    "overlap": 1000
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092656": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 252.133,
+                "max_elevation": 340.2229,
+                "xs_id": 12.67
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 248.458,
+                "max_elevation": 337.9269,
+                "xs_id": 12.2
+            },
+            "eclipsed": false,
+            "low_flow": 313007,
+            "high_flow": 2272449,
+            "network_to_id": "5092660",
+            "ds_slope": 3.9999998989515007e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 40,
+                        "std": 16,
+                        "min": 29,
+                        "25%": 34,
+                        "50%": 40,
+                        "75%": 45,
+                        "max": 51
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 115,
+                        "std": 3,
+                        "min": 113,
+                        "25%": 114,
+                        "50%": 115,
+                        "75%": 116,
+                        "max": 117
+                    }
+                },
+                "lengths": {
+                    "ras": 2408,
+                    "network": 2385,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.99,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092660",
+                    "overlap": 2367
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5093448": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 254.19,
+                "max_elevation": 335.68,
+                "xs_id": 2.67
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 250.24,
+                "max_elevation": 334.67,
+                "xs_id": 1.39
+            },
+            "eclipsed": false,
+            "low_flow": 313306,
+            "high_flow": 2242718,
+            "network_to_id": "5093446",
+            "ds_slope": 0.00033000000985339284,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 7,
+                        "mean": 41,
+                        "std": 60,
+                        "min": 15,
+                        "25%": 18,
+                        "50%": 19,
+                        "75%": 20,
+                        "max": 178
+                    },
+                    "thalweg_offset": {
+                        "count": 7,
+                        "mean": 509,
+                        "std": 224,
+                        "min": 95,
+                        "25%": 423,
+                        "50%": 590,
+                        "75%": 615,
+                        "max": 799
+                    }
+                },
+                "lengths": {
+                    "ras": 6724,
+                    "network": 6754,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.0,
+                    "end": 0.73
+                }
+            },
+            "overlapped_reaches": [],
+            "eclipsed_reaches": []
+        },
+        "5092658": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 266.437,
+                "max_elevation": 328.15,
+                "xs_id": 15.43
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 252.133,
+                "max_elevation": 340.2229,
+                "xs_id": 12.67
+            },
+            "eclipsed": false,
+            "low_flow": 313008,
+            "high_flow": 2272411,
+            "network_to_id": "5092656",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 7,
+                        "mean": 64,
+                        "std": 36,
+                        "min": 6,
+                        "25%": 44,
+                        "50%": 71,
+                        "75%": 84,
+                        "max": 114
+                    },
+                    "thalweg_offset": {
+                        "count": 7,
+                        "mean": 337,
+                        "std": 233,
+                        "min": 108,
+                        "25%": 157,
+                        "50%": 202,
+                        "75%": 541,
+                        "max": 655
+                    }
+                },
+                "lengths": {
+                    "ras": 12587,
+                    "network": 13001,
+                    "network_to_ras_ratio": 1.03
+                },
+                "coverage": {
+                    "start": 0.07,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092656",
+                    "overlap": 2302
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5093444": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 278.084,
+                "max_elevation": 340.2229,
+                "xs_id": 24.49
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 272.507,
+                "max_elevation": 339.567,
+                "xs_id": 22.03
+            },
+            "eclipsed": false,
+            "low_flow": 313062,
+            "high_flow": 2272490,
+            "network_to_id": "5092710",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 26,
+                        "std": 26,
+                        "min": 3,
+                        "25%": 8,
+                        "50%": 21,
+                        "75%": 30,
+                        "max": 74
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 153,
+                        "std": 67,
+                        "min": 89,
+                        "25%": 111,
+                        "50%": 150,
+                        "75%": 155,
+                        "max": 276
+                    }
+                },
+                "lengths": {
+                    "ras": 15881,
+                    "network": 15624,
+                    "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092704",
+                    "overlap": 386
+                }
+            ],
+            "eclipsed_reaches": [
+                "5092710"
+            ]
+        },
+        "5092712": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 275.459,
+                "max_elevation": 342.95,
+                "xs_id": 28.57
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 278.084,
+                "max_elevation": 340.2229,
+                "xs_id": 24.49
+            },
+            "eclipsed": false,
+            "low_flow": 313109,
+            "high_flow": 2272707,
+            "network_to_id": "5093444",
+            "ds_slope": 0.00016999999934341758,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 8,
+                        "mean": 33,
+                        "std": 37,
+                        "min": 3,
+                        "25%": 4,
+                        "50%": 15,
+                        "75%": 59,
+                        "max": 95
+                    },
+                    "thalweg_offset": {
+                        "count": 8,
+                        "mean": 235,
+                        "std": 122,
+                        "min": 89,
+                        "25%": 189,
+                        "50%": 216,
+                        "75%": 234,
+                        "max": 513
+                    }
+                },
+                "lengths": {
+                    "ras": 21765,
+                    "network": 21946,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.07,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5093444",
+                    "overlap": 1188
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092704": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 272.507,
+                "max_elevation": 339.567,
+                "xs_id": 22.03
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 264.698,
+                "max_elevation": 340.2102,
+                "xs_id": 18.05
+            },
+            "eclipsed": false,
+            "low_flow": 313045,
+            "high_flow": 2272440,
+            "network_to_id": "5092684",
+            "ds_slope": 0.00016999999934341758,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 10,
+                        "mean": 15,
+                        "std": 8,
+                        "min": 4,
+                        "25%": 10,
+                        "50%": 13,
+                        "75%": 19,
+                        "max": 32
+                    },
+                    "thalweg_offset": {
+                        "count": 10,
+                        "mean": 208,
+                        "std": 115,
+                        "min": 59,
+                        "25%": 150,
+                        "50%": 173,
+                        "75%": 212,
+                        "max": 433
+                    }
+                },
+                "lengths": {
+                    "ras": 20504,
+                    "network": 20561,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.02,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092684",
+                    "overlap": 1429
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092664": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 264.075,
+                "max_elevation": 323.819,
+                "xs_id": 16.95
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 266.437,
+                "max_elevation": 328.15,
+                "xs_id": 15.43
+            },
+            "eclipsed": false,
+            "low_flow": 313038,
+            "high_flow": 2272582,
+            "network_to_id": "5092658",
+            "ds_slope": 0.0002800000074785203,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 29,
+                        "std": 14,
+                        "min": 9,
+                        "25%": 26,
+                        "50%": 34,
+                        "75%": 38,
+                        "max": 40
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 170,
+                        "std": 224,
+                        "min": 6,
+                        "25%": 60,
+                        "50%": 86,
+                        "75%": 196,
+                        "max": 501
+                    }
+                },
+                "lengths": {
+                    "ras": 7956,
+                    "network": 8175,
+                    "network_to_ras_ratio": 1.03
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092658",
+                    "overlap": 850
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092670": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 230.282,
+                "max_elevation": 323.491,
+                "xs_id": 17.25
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 264.075,
+                "max_elevation": 323.819,
+                "xs_id": 16.95
+            },
+            "eclipsed": false,
+            "low_flow": 313040,
+            "high_flow": 2272558,
+            "network_to_id": "5092664",
+            "ds_slope": 0.00023999999393709004,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 33,
+                        "std": 10,
+                        "min": 26,
+                        "25%": 30,
+                        "50%": 33,
+                        "75%": 37,
+                        "max": 40
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 212,
+                        "std": 290,
+                        "min": 6,
+                        "25%": 109,
+                        "50%": 212,
+                        "75%": 314,
+                        "max": 417
+                    }
+                },
+                "lengths": {
+                    "ras": 1597,
+                    "network": 1666,
+                    "network_to_ras_ratio": 1.04
+                },
+                "coverage": {
+                    "start": 0.29,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092664",
+                    "overlap": 611
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5092684": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 264.698,
+                "max_elevation": 340.2102,
+                "xs_id": 18.05
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 230.282,
+                "max_elevation": 323.491,
+                "xs_id": 17.25
+            },
+            "eclipsed": false,
+            "low_flow": 313040,
+            "high_flow": 2272524,
+            "network_to_id": "5092670",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 25,
+                        "std": 14,
+                        "min": 4,
+                        "25%": 21,
+                        "50%": 29,
+                        "75%": 33,
+                        "max": 37
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 366,
+                        "std": 42,
+                        "min": 326,
+                        "25%": 334,
+                        "50%": 361,
+                        "75%": 393,
+                        "max": 417
+                    }
+                },
+                "lengths": {
+                    "ras": 4478,
+                    "network": 4477,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.26,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5092670",
+                    "overlap": 440
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5093450": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 260.61,
+                "max_elevation": 336.55,
+                "xs_id": 4.58
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 3",
+                "min_elevation": 254.19,
+                "max_elevation": 335.68,
+                "xs_id": 2.67
+            },
+            "eclipsed": false,
+            "low_flow": 313307,
+            "high_flow": 2242809,
+            "network_to_id": "5093448",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 4,
+                        "mean": 75,
+                        "std": 78,
+                        "min": 6,
+                        "25%": 19,
+                        "50%": 59,
+                        "75%": 115,
+                        "max": 178
+                    },
+                    "thalweg_offset": {
+                        "count": 4,
+                        "mean": 452,
+                        "std": 381,
+                        "min": 95,
+                        "25%": 136,
+                        "50%": 459,
+                        "75%": 774,
+                        "max": 795
+                    }
+                },
+                "lengths": {
+                    "ras": 10309,
+                    "network": 10111,
+                    "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.09,
+                    "end": 1.0
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5093448",
+                    "overlap": 8
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089922": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 308.77,
+                "max_elevation": 399.97,
+                "xs_id": 91.83
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 306.01,
+                "max_elevation": 399.91,
+                "xs_id": 91.32
+            },
+            "eclipsed": false,
+            "low_flow": 311306,
+            "high_flow": 2277489,
+            "network_to_id": "5089926",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 25,
+                        "std": 24,
+                        "min": 8,
+                        "25%": 17,
+                        "50%": 25,
+                        "75%": 34,
+                        "max": 43
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 79,
+                        "std": 7,
+                        "min": 73,
+                        "25%": 76,
+                        "50%": 79,
+                        "75%": 81,
+                        "max": 84
+                    }
+                },
+                "lengths": {
+                    "ras": 2680,
+                    "network": 2719,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.08,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089926",
+                    "overlap": 359
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089920": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 287.72,
+                "max_elevation": 400.06,
+                "xs_id": 94.37
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 308.77,
+                "max_elevation": 399.97,
+                "xs_id": 91.83
+            },
+            "eclipsed": false,
+            "low_flow": 311305,
+            "high_flow": 2277445,
+            "network_to_id": "5089922",
+            "ds_slope": 1.9999999494757503e-05,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 45,
+                        "std": 39,
+                        "min": 8,
+                        "25%": 20,
+                        "50%": 38,
+                        "75%": 51,
+                        "max": 117
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 70,
+                        "std": 43,
+                        "min": 22,
+                        "25%": 34,
+                        "50%": 75,
+                        "75%": 85,
+                        "max": 137
+                    }
+                },
+                "lengths": {
+                    "ras": 11351,
+                    "network": 11188,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.03,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089922",
+                    "overlap": 192
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089914": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 307.17,
+                "max_elevation": 400.11,
+                "xs_id": 97.15
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 287.72,
+                "max_elevation": 400.06,
+                "xs_id": 94.37
+            },
+            "eclipsed": false,
+            "low_flow": 311248,
+            "high_flow": 2277381,
+            "network_to_id": "5089920",
+            "ds_slope": 0.00013000000035390258,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 50,
+                        "std": 39,
+                        "min": 16,
+                        "25%": 18,
+                        "50%": 36,
+                        "75%": 84,
+                        "max": 100
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 231,
+                        "std": 156,
+                        "min": 24,
+                        "25%": 105,
+                        "50%": 280,
+                        "75%": 339,
+                        "max": 400
+                    }
+                },
+                "lengths": {
+                    "ras": 14469,
+                    "network": 14254,
+                    "network_to_ras_ratio": 0.99
+                },
+                "coverage": {
+                    "start": 0.17,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089920",
+                    "overlap": 397
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089912": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 315.0,
+                "max_elevation": 399.97,
+                "xs_id": 106.23
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 307.17,
+                "max_elevation": 400.11,
+                "xs_id": 97.15
+            },
+            "eclipsed": false,
+            "low_flow": 311249,
+            "high_flow": 2277484,
+            "network_to_id": "5089914",
+            "ds_slope": 0.00011000000085914508,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 18,
+                        "mean": 113,
+                        "std": 52,
+                        "min": 19,
+                        "25%": 88,
+                        "50%": 104,
+                        "75%": 152,
+                        "max": 197
+                    },
+                    "thalweg_offset": {
+                        "count": 18,
+                        "mean": 332,
+                        "std": 104,
+                        "min": 153,
+                        "25%": 276,
+                        "50%": 326,
+                        "75%": 397,
+                        "max": 510
+                    }
+                },
+                "lengths": {
+                    "ras": 47435,
+                    "network": 47243,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.02,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089914",
+                    "overlap": 2921
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5089904": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 315.74,
+                "max_elevation": 400.13,
+                "xs_id": 109.93
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 315.0,
+                "max_elevation": 399.97,
+                "xs_id": 106.23
+            },
+            "eclipsed": false,
+            "low_flow": 311293,
+            "high_flow": 2277393,
+            "network_to_id": "5089912",
+            "ds_slope": 0.00011999999696854502,
+            "gage": "07020500",
+            "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07020500&legacy=1",
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 11,
+                        "mean": 50,
+                        "std": 25,
+                        "min": 1,
+                        "25%": 42,
+                        "50%": 53,
+                        "75%": 58,
+                        "max": 98
+                    },
+                    "thalweg_offset": {
+                        "count": 11,
+                        "mean": 144,
+                        "std": 60,
+                        "min": 12,
+                        "25%": 131,
+                        "50%": 158,
+                        "75%": 188,
+                        "max": 198
+                    }
+                },
+                "lengths": {
+                    "ras": 19363,
+                    "network": 19372,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.11,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5089912",
+                    "overlap": 1122
                 }
             ],
             "eclipsed_reaches": []
@@ -266,29 +3569,30 @@
                 "xs_id": 109.93
             },
             "eclipsed": false,
-            "low_flow": 414689,
-            "high_flow": 1896167,
+            "low_flow": 311017,
+            "high_flow": 2275401,
             "network_to_id": "5089904",
+            "ds_slope": 4.999999873689376e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 11,
-                        "mean": 29,
-                        "std": 15,
+                        "count": 10,
+                        "mean": 31,
+                        "std": 14,
                         "min": 2,
-                        "25%": 23,
-                        "50%": 28,
-                        "75%": 41,
+                        "25%": 24,
+                        "50%": 29,
+                        "75%": 44,
                         "max": 50
                     },
                     "thalweg_offset": {
-                        "count": 11,
-                        "mean": 222,
-                        "std": 74,
+                        "count": 10,
+                        "mean": 216,
+                        "std": 76,
                         "min": 46,
-                        "25%": 193,
-                        "50%": 238,
-                        "75%": 278,
+                        "25%": 192,
+                        "50%": 221,
+                        "75%": 273,
                         "max": 292
                     }
                 },
@@ -308,14 +3612,63 @@
                     "overlap": 2253
                 }
             ],
-            "eclipsed_reaches": [
-                "5088588",
-                "5089908",
-                "5088576",
-                "5089892",
-                "5089894",
-                "5089906"
-            ]
+            "eclipsed_reaches": []
+        },
+        "5088542": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 361.98,
+                "max_elevation": 406.99,
+                "xs_id": 115.76
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 2",
+                "min_elevation": 319.51,
+                "max_elevation": 399.99,
+                "xs_id": 110.4
+            },
+            "eclipsed": false,
+            "low_flow": 742,
+            "high_flow": 51750,
+            "network_to_id": "5089894",
+            "ds_slope": 0.0001500000071246177,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 12,
+                        "mean": 496,
+                        "std": 487,
+                        "min": 61,
+                        "25%": 185,
+                        "50%": 351,
+                        "75%": 616,
+                        "max": 1755
+                    },
+                    "thalweg_offset": {
+                        "count": 12,
+                        "mean": 1788,
+                        "std": 1222,
+                        "min": 126,
+                        "25%": 934,
+                        "50%": 1655,
+                        "75%": 2416,
+                        "max": 4032
+                    }
+                },
+                "lengths": {
+                    "ras": 35556,
+                    "network": 28540,
+                    "network_to_ras_ratio": 0.8
+                },
+                "coverage": {
+                    "start": 0.12,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [],
+            "eclipsed_reaches": []
         },
         "3630825": {
             "us_xs": {
@@ -333,9 +3686,10 @@
                 "xs_id": 122.13
             },
             "eclipsed": false,
-            "low_flow": 410602,
-            "high_flow": 1894358,
+            "low_flow": 307951,
+            "high_flow": 2273230,
             "network_to_id": "3630829",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -375,11 +3729,7 @@
                     "overlap": 609
                 }
             ],
-            "eclipsed_reaches": [
-                "3630827",
-                "13892798",
-                "13894102"
-            ]
+            "eclipsed_reaches": []
         },
         "3629943": {
             "us_xs": {
@@ -397,9 +3747,10 @@
                 "xs_id": 118.21
             },
             "eclipsed": false,
-            "low_flow": 410618,
-            "high_flow": 1894180,
+            "low_flow": 307963,
+            "high_flow": 2273017,
             "network_to_id": "5090052",
+            "ds_slope": 0.00013000000035390258,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -439,9 +3790,7 @@
                     "overlap": 117
                 }
             ],
-            "eclipsed_reaches": [
-                "13894316"
-            ]
+            "eclipsed_reaches": []
         },
         "3630829": {
             "us_xs": {
@@ -459,9 +3808,10 @@
                 "xs_id": 120.65
             },
             "eclipsed": false,
-            "low_flow": 410621,
-            "high_flow": 1894453,
+            "low_flow": 307965,
+            "high_flow": 2273343,
             "network_to_id": "3629943",
+            "ds_slope": 0.0002500000118743628,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -519,9 +3869,10 @@
                 "xs_id": 117.41
             },
             "eclipsed": false,
-            "low_flow": 410621,
-            "high_flow": 1894259,
+            "low_flow": 307966,
+            "high_flow": 2273110,
             "network_to_id": "5089872",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -562,13 +3913,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "5088356",
-                "5089874",
-                "5089876",
-                "5089878",
-                "5089872",
-                "13894312",
-                "13894314"
+                "5089872"
             ]
         },
         "5089888": {
@@ -587,9 +3932,10 @@
                 "xs_id": 115.24
             },
             "eclipsed": false,
-            "low_flow": 414806,
-            "high_flow": 1897788,
+            "low_flow": 311105,
+            "high_flow": 2277346,
             "network_to_id": "5089890",
+            "ds_slope": 0.00018000000272877514,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -629,22 +3975,70 @@
                     "overlap": 631
                 }
             ],
+            "eclipsed_reaches": []
+        },
+        "5088480": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 366.35,
+                "max_elevation": 411.54,
+                "xs_id": 118.64
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 365.62,
+                "max_elevation": 400.12,
+                "xs_id": 117.92
+            },
+            "eclipsed": false,
+            "low_flow": 272,
+            "high_flow": 14237,
+            "network_to_id": "5088488",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 382,
+                        "std": 231,
+                        "min": 190,
+                        "25%": 254,
+                        "50%": 317,
+                        "75%": 478,
+                        "max": 638
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 848,
+                        "std": 827,
+                        "min": 183,
+                        "25%": 385,
+                        "50%": 587,
+                        "75%": 1181,
+                        "max": 1775
+                    }
+                },
+                "lengths": {
+                    "ras": 9115,
+                    "network": 9860,
+                    "network_to_ras_ratio": 1.08
+                },
+                "coverage": {
+                    "start": 0.01,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5088524",
+                    "overlap": 133
+                }
+            ],
             "eclipsed_reaches": [
-                "5089884",
-                "5089886"
+                "5088488"
             ]
-        },
-        "5089872": {
-            "eclipsed": true,
-            "low_flow": 410623,
-            "high_flow": 1894306,
-            "network_to_id": "5089868"
-        },
-        "5089870": {
-            "eclipsed": true,
-            "low_flow": 414806,
-            "high_flow": 1897908,
-            "network_to_id": "5089880"
         },
         "5089868": {
             "us_xs": {
@@ -662,9 +4056,10 @@
                 "xs_id": 116.88
             },
             "eclipsed": false,
-            "low_flow": 414808,
-            "high_flow": 1897944,
+            "low_flow": 311106,
+            "high_flow": 2277533,
             "network_to_id": "5089870",
+            "ds_slope": 0.0004400000034365803,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -724,9 +4119,10 @@
                 "xs_id": 115.76
             },
             "eclipsed": false,
-            "low_flow": 414805,
-            "high_flow": 1897835,
+            "low_flow": 311104,
+            "high_flow": 2277402,
             "network_to_id": "5089888",
+            "ds_slope": 7.999999797903001e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -766,9 +4162,129 @@
                     "overlap": 1071
                 }
             ],
-            "eclipsed_reaches": [
-                "5089882"
-            ]
+            "eclipsed_reaches": []
+        },
+        "5088536": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 361.27,
+                "max_elevation": 420.08,
+                "xs_id": 116.88
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 361.98,
+                "max_elevation": 406.99,
+                "xs_id": 115.76
+            },
+            "eclipsed": false,
+            "low_flow": 739,
+            "high_flow": 52886,
+            "network_to_id": "5088542",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 173,
+                        "std": 151,
+                        "min": 75,
+                        "25%": 86,
+                        "50%": 97,
+                        "75%": 222,
+                        "max": 347
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 186,
+                        "std": 80,
+                        "min": 126,
+                        "25%": 141,
+                        "50%": 156,
+                        "75%": 216,
+                        "max": 277
+                    }
+                },
+                "lengths": {
+                    "ras": 7652,
+                    "network": 7864,
+                    "network_to_ras_ratio": 1.03
+                },
+                "coverage": {
+                    "start": 0.22,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5088542",
+                    "overlap": 3433
+                }
+            ],
+            "eclipsed_reaches": []
+        },
+        "5088524": {
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 365.62,
+                "max_elevation": 400.12,
+                "xs_id": 117.92
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Kaskaskia Island",
+                "min_elevation": 361.27,
+                "max_elevation": 420.08,
+                "xs_id": 116.88
+            },
+            "eclipsed": false,
+            "low_flow": 265,
+            "high_flow": 13680,
+            "network_to_id": "5088536",
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 3,
+                        "mean": 440,
+                        "std": 298,
+                        "min": 97,
+                        "25%": 341,
+                        "50%": 585,
+                        "75%": 611,
+                        "max": 638
+                    },
+                    "thalweg_offset": {
+                        "count": 3,
+                        "mean": 931,
+                        "std": 812,
+                        "min": 156,
+                        "25%": 509,
+                        "50%": 861,
+                        "75%": 1318,
+                        "max": 1775
+                    }
+                },
+                "lengths": {
+                    "ras": 9008,
+                    "network": 8861,
+                    "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.02,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "5088536",
+                    "overlap": 1272
+                }
+            ],
+            "eclipsed_reaches": []
         },
         "3630823": {
             "us_xs": {
@@ -786,9 +4302,10 @@
                 "xs_id": 122.72
             },
             "eclipsed": false,
-            "low_flow": 410601,
-            "high_flow": 1894281,
+            "low_flow": 307951,
+            "high_flow": 2273138,
             "network_to_id": "3630825",
+            "ds_slope": 0.0003499999875202775,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -828,30 +4345,7 @@
                     "overlap": 1117
                 }
             ],
-            "eclipsed_reaches": [
-                "3630819",
-                "13894094",
-                "13894092",
-                "13894096",
-                "13894174",
-                "13892730",
-                "13892722",
-                "13892720",
-                "13892740",
-                "13892724",
-                "13894086",
-                "13892746",
-                "13892750",
-                "13892738",
-                "13892744",
-                "13892748",
-                "13894088",
-                "13892710",
-                "13892708",
-                "13892718",
-                "3630469",
-                "3634865"
-            ]
+            "eclipsed_reaches": []
         },
         "3629267": {
             "us_xs": {
@@ -869,9 +4363,10 @@
                 "xs_id": 123.93
             },
             "eclipsed": false,
-            "low_flow": 410588,
-            "high_flow": 1894334,
+            "low_flow": 307941,
+            "high_flow": 2273201,
             "network_to_id": "3630817",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -912,26 +4407,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "3628623",
-                "3628617",
-                "3630817",
-                "3628739",
-                "3629265",
-                "3630821",
-                "3628655",
-                "3628565",
-                "3628653",
-                "3628607",
-                "3628595",
-                "3628597",
-                "3628613"
+                "3630817"
             ]
-        },
-        "3630817": {
-            "eclipsed": true,
-            "low_flow": 410587,
-            "high_flow": 1894296,
-            "network_to_id": "3630823"
         },
         "3629263": {
             "us_xs": {
@@ -949,9 +4426,10 @@
                 "xs_id": 125.6
             },
             "eclipsed": false,
-            "low_flow": 410587,
-            "high_flow": 1894439,
+            "low_flow": 307940,
+            "high_flow": 2273327,
             "network_to_id": "3629267",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -991,11 +4469,7 @@
                     "overlap": 79
                 }
             ],
-            "eclipsed_reaches": [
-                "3628475",
-                "3628705",
-                "3629261"
-            ]
+            "eclipsed_reaches": []
         },
         "3629257": {
             "us_xs": {
@@ -1013,9 +4487,10 @@
                 "xs_id": 127.0
             },
             "eclipsed": false,
-            "low_flow": 410596,
-            "high_flow": 1894603,
+            "low_flow": 307947,
+            "high_flow": 2273524,
             "network_to_id": "3629263",
+            "ds_slope": 0.00015999999595806003,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1055,9 +4530,7 @@
                     "overlap": 1986
                 }
             ],
-            "eclipsed_reaches": [
-                "3629259"
-            ]
+            "eclipsed_reaches": []
         },
         "3629237": {
             "us_xs": {
@@ -1075,9 +4548,10 @@
                 "xs_id": 129.39
             },
             "eclipsed": false,
-            "low_flow": 410449,
-            "high_flow": 1894137,
+            "low_flow": 307836,
+            "high_flow": 2272965,
             "network_to_id": "3629241",
+            "ds_slope": 0.00031999999191612005,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1117,14 +4591,7 @@
                     "overlap": 2146
                 }
             ],
-            "eclipsed_reaches": [
-                "3628353",
-                "3628283",
-                "3629235",
-                "3628437",
-                "3629287",
-                "3628277"
-            ]
+            "eclipsed_reaches": []
         },
         "3624727": {
             "us_xs": {
@@ -1142,9 +4609,10 @@
                 "xs_id": 180.77
             },
             "eclipsed": false,
-            "low_flow": 406233,
-            "high_flow": 1940520,
+            "low_flow": 304675,
+            "high_flow": 2328624,
             "network_to_id": "3624735",
+            "ds_slope": 0.000539999979082495,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1184,9 +4652,7 @@
                     "overlap": 1715
                 }
             ],
-            "eclipsed_reaches": [
-                "3624725"
-            ]
+            "eclipsed_reaches": []
         },
         "3624705": {
             "us_xs": {
@@ -1204,9 +4670,10 @@
                 "xs_id": 190.85
             },
             "eclipsed": false,
-            "low_flow": 406051,
-            "high_flow": 1941422,
+            "low_flow": 304538,
+            "high_flow": 2329706,
             "network_to_id": "3624709",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1246,9 +4713,7 @@
                     "overlap": 845
                 }
             ],
-            "eclipsed_reaches": [
-                "3624707"
-            ]
+            "eclipsed_reaches": []
         },
         "3624715": {
             "us_xs": {
@@ -1266,9 +4731,10 @@
                 "xs_id": 186.82
             },
             "eclipsed": false,
-            "low_flow": 406050,
-            "high_flow": 1940720,
+            "low_flow": 304537,
+            "high_flow": 2328865,
             "network_to_id": "3634823",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1308,9 +4774,7 @@
                     "overlap": 1441
                 }
             ],
-            "eclipsed_reaches": [
-                "3624717"
-            ]
+            "eclipsed_reaches": []
         },
         "3624723": {
             "us_xs": {
@@ -1328,9 +4792,10 @@
                 "xs_id": 183.38
             },
             "eclipsed": false,
-            "low_flow": 406190,
-            "high_flow": 1940409,
+            "low_flow": 304642,
+            "high_flow": 2328491,
             "network_to_id": "3624727",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1370,15 +4835,7 @@
                     "overlap": 2766
                 }
             ],
-            "eclipsed_reaches": [
-                "3624721"
-            ]
-        },
-        "3629227": {
-            "eclipsed": true,
-            "low_flow": 410427,
-            "high_flow": 1894201,
-            "network_to_id": "3629237"
+            "eclipsed_reaches": []
         },
         "3629229": {
             "us_xs": {
@@ -1396,9 +4853,10 @@
                 "xs_id": 131.76
             },
             "eclipsed": false,
-            "low_flow": 410426,
-            "high_flow": 1894221,
+            "low_flow": 307819,
+            "high_flow": 2273066,
             "network_to_id": "3629227",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1439,22 +4897,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "3628289",
-                "3629225",
-                "3629285",
-                "3628227",
-                "3628097",
-                "3628389",
-                "3628393",
-                "3628433",
-                "3628285",
-                "3628207",
-                "3629223",
-                "937140099",
-                "937140100",
-                "3628229",
-                "3629227",
-                "3628211"
+                "3629227"
             ]
         },
         "3629247": {
@@ -1473,9 +4916,10 @@
                 "xs_id": 128.0
             },
             "eclipsed": false,
-            "low_flow": 410592,
-            "high_flow": 1894624,
+            "low_flow": 307944,
+            "high_flow": 2273549,
             "network_to_id": "3629257",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1533,9 +4977,10 @@
                 "xs_id": 128.5
             },
             "eclipsed": false,
-            "low_flow": 410453,
-            "high_flow": 1894191,
+            "low_flow": 307839,
+            "high_flow": 2273029,
             "network_to_id": "3629247",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1575,12 +5020,7 @@
                     "overlap": 394
                 }
             ],
-            "eclipsed_reaches": [
-                "3628593",
-                "3629243",
-                "3629245",
-                "3628423"
-            ]
+            "eclipsed_reaches": []
         },
         "3629217": {
             "us_xs": {
@@ -1598,9 +5038,10 @@
                 "xs_id": 134.88
             },
             "eclipsed": false,
-            "low_flow": 410439,
-            "high_flow": 1894401,
+            "low_flow": 307829,
+            "high_flow": 2273281,
             "network_to_id": "3629221",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1640,9 +5081,7 @@
                     "overlap": 60
                 }
             ],
-            "eclipsed_reaches": [
-                "3629219"
-            ]
+            "eclipsed_reaches": []
         },
         "3629221": {
             "us_xs": {
@@ -1660,9 +5099,10 @@
                 "xs_id": 133.31
             },
             "eclipsed": false,
-            "low_flow": 410433,
-            "high_flow": 1894296,
+            "low_flow": 307825,
+            "high_flow": 2273155,
             "network_to_id": "3629229",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1702,15 +5142,7 @@
                     "overlap": 1193
                 }
             ],
-            "eclipsed_reaches": [
-                "3629233",
-                "3629231",
-                "3628085",
-                "3628177",
-                "3628103",
-                "3628065",
-                "3628179"
-            ]
+            "eclipsed_reaches": []
         },
         "3634869": {
             "us_xs": {
@@ -1728,9 +5160,10 @@
                 "xs_id": 188.88
             },
             "eclipsed": false,
-            "low_flow": 406063,
-            "high_flow": 1941247,
+            "low_flow": 304547,
+            "high_flow": 2329497,
             "network_to_id": "3624715",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1770,9 +5203,7 @@
                     "overlap": 1095
                 }
             ],
-            "eclipsed_reaches": [
-                "3624771"
-            ]
+            "eclipsed_reaches": []
         },
         "3624711": {
             "us_xs": {
@@ -1790,9 +5221,10 @@
                 "xs_id": 189.47
             },
             "eclipsed": false,
-            "low_flow": 406064,
-            "high_flow": 1941228,
+            "low_flow": 304548,
+            "high_flow": 2329474,
             "network_to_id": "3634869",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1832,9 +5264,7 @@
                     "overlap": 554
                 }
             ],
-            "eclipsed_reaches": [
-                "3624713"
-            ]
+            "eclipsed_reaches": []
         },
         "3624709": {
             "us_xs": {
@@ -1852,9 +5282,10 @@
                 "xs_id": 190.29
             },
             "eclipsed": false,
-            "low_flow": 406064,
-            "high_flow": 1941284,
+            "low_flow": 304548,
+            "high_flow": 2329541,
             "network_to_id": "3624711",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1896,12 +5327,6 @@
             ],
             "eclipsed_reaches": []
         },
-        "3629209": {
-            "eclipsed": true,
-            "low_flow": 410435,
-            "high_flow": 1894466,
-            "network_to_id": "3629213"
-        },
         "3629213": {
             "us_xs": {
                 "river": "Mississippi",
@@ -1918,9 +5343,10 @@
                 "xs_id": 135.5
             },
             "eclipsed": false,
-            "low_flow": 410435,
-            "high_flow": 1894442,
+            "low_flow": 307826,
+            "high_flow": 2273330,
             "network_to_id": "3629217",
+            "ds_slope": 0.00014000000373926014,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1960,16 +5386,70 @@
                     "overlap": 757
                 }
             ],
-            "eclipsed_reaches": [
-                "3629283",
-                "3629215"
-            ]
+            "eclipsed_reaches": []
         },
         "3629205": {
-            "eclipsed": true,
-            "low_flow": 410432,
-            "high_flow": 1894456,
-            "network_to_id": "3629209"
+            "us_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 1",
+                "min_elevation": 338.87,
+                "max_elevation": 419.91,
+                "xs_id": 136.48
+            },
+            "ds_xs": {
+                "river": "Mississippi",
+                "reach": "Reach 1",
+                "min_elevation": 338.1,
+                "max_elevation": 420.06,
+                "xs_id": 136.0
+            },
+            "eclipsed": false,
+            "low_flow": 307824,
+            "high_flow": 2273347,
+            "network_to_id": "3629209",
+            "ds_slope": 0.002589999930933118,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 2,
+                        "mean": 129,
+                        "std": 22,
+                        "min": 113,
+                        "25%": 121,
+                        "50%": 129,
+                        "75%": 136,
+                        "max": 144
+                    },
+                    "thalweg_offset": {
+                        "count": 2,
+                        "mean": 151,
+                        "std": 188,
+                        "min": 18,
+                        "25%": 84,
+                        "50%": 151,
+                        "75%": 217,
+                        "max": 284
+                    }
+                },
+                "lengths": {
+                    "ras": 2579,
+                    "network": 2570,
+                    "network_to_ras_ratio": 1.0
+                },
+                "coverage": {
+                    "start": 0.0,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "3629213",
+                    "overlap": 1251
+                }
+            ],
+            "eclipsed_reaches": [
+                "3629209"
+            ]
         },
         "3629197": {
             "us_xs": {
@@ -1987,9 +5467,10 @@
                 "xs_id": 136.48
             },
             "eclipsed": false,
-            "low_flow": 410367,
-            "high_flow": 1894064,
+            "low_flow": 307775,
+            "high_flow": 2272877,
             "network_to_id": "3629203",
+            "ds_slope": 0.00046999999904073775,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2030,21 +5511,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "3627881",
                 "3629203"
             ]
-        },
-        "3629191": {
-            "eclipsed": true,
-            "low_flow": 410365,
-            "high_flow": 1894093,
-            "network_to_id": "3629197"
-        },
-        "3629203": {
-            "eclipsed": true,
-            "low_flow": 410367,
-            "high_flow": 1894147,
-            "network_to_id": "3629205"
         },
         "3629159": {
             "us_xs": {
@@ -2062,9 +5530,10 @@
                 "xs_id": 145.35
             },
             "eclipsed": false,
-            "low_flow": 410401,
-            "high_flow": 1895131,
+            "low_flow": 307801,
+            "high_flow": 2274158,
             "network_to_id": "3629163",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2104,9 +5573,7 @@
                     "overlap": 875
                 }
             ],
-            "eclipsed_reaches": [
-                "3629161"
-            ]
+            "eclipsed_reaches": []
         },
         "3629155": {
             "us_xs": {
@@ -2124,9 +5591,10 @@
                 "xs_id": 145.82
             },
             "eclipsed": false,
-            "low_flow": 410399,
-            "high_flow": 1895308,
+            "low_flow": 307799,
+            "high_flow": 2274370,
             "network_to_id": "3629159",
+            "ds_slope": 5.999999848427251e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2166,9 +5634,7 @@
                     "overlap": 2453
                 }
             ],
-            "eclipsed_reaches": [
-                "3629157"
-            ]
+            "eclipsed_reaches": []
         },
         "3629135": {
             "us_xs": {
@@ -2186,9 +5652,10 @@
                 "xs_id": 150.19
             },
             "eclipsed": false,
-            "low_flow": 410362,
-            "high_flow": 1895760,
+            "low_flow": 307771,
+            "high_flow": 2274912,
             "network_to_id": "3629147",
+            "ds_slope": 0.00031999999191612005,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2228,9 +5695,7 @@
                     "overlap": 695
                 }
             ],
-            "eclipsed_reaches": [
-                "3629137"
-            ]
+            "eclipsed_reaches": []
         },
         "3629147": {
             "us_xs": {
@@ -2248,9 +5713,10 @@
                 "xs_id": 148.25
             },
             "eclipsed": false,
-            "low_flow": 410359,
-            "high_flow": 1895575,
+            "low_flow": 307769,
+            "high_flow": 2274690,
             "network_to_id": "3629155",
+            "ds_slope": 0.0003000000142492354,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2290,10 +5756,7 @@
                     "overlap": 53
                 }
             ],
-            "eclipsed_reaches": [
-                "3629149",
-                "3629279"
-            ]
+            "eclipsed_reaches": []
         },
         "3629127": {
             "us_xs": {
@@ -2311,9 +5774,10 @@
                 "xs_id": 151.14
             },
             "eclipsed": false,
-            "low_flow": 410270,
-            "high_flow": 1896331,
+            "low_flow": 307702,
+            "high_flow": 2275597,
             "network_to_id": "3629135",
+            "ds_slope": 9.000000136438757e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2353,15 +5817,7 @@
                     "overlap": 1269
                 }
             ],
-            "eclipsed_reaches": [
-                "3629129",
-                "3627291",
-                "937140102",
-                "3627289",
-                "3627247",
-                "937140052",
-                "937140053"
-            ]
+            "eclipsed_reaches": []
         },
         "3629119": {
             "us_xs": {
@@ -2379,9 +5835,10 @@
                 "xs_id": 152.94
             },
             "eclipsed": false,
-            "low_flow": 410279,
-            "high_flow": 1896368,
+            "low_flow": 307709,
+            "high_flow": 2275642,
             "network_to_id": "3629127",
+            "ds_slope": 9.999999747378752e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2421,10 +5878,7 @@
                     "overlap": 1096
                 }
             ],
-            "eclipsed_reaches": [
-                "3629121",
-                "3627115"
-            ]
+            "eclipsed_reaches": []
         },
         "3629097": {
             "us_xs": {
@@ -2442,9 +5896,10 @@
                 "xs_id": 154.6
             },
             "eclipsed": false,
-            "low_flow": 410282,
-            "high_flow": 1896594,
+            "low_flow": 307711,
+            "high_flow": 2275912,
             "network_to_id": "3629119",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2484,12 +5939,7 @@
                     "overlap": 4822
                 }
             ],
-            "eclipsed_reaches": [
-                "3629099",
-                "3629331",
-                "3629105",
-                "3629103"
-            ]
+            "eclipsed_reaches": []
         },
         "3629089": {
             "us_xs": {
@@ -2507,9 +5957,10 @@
                 "xs_id": 156.02
             },
             "eclipsed": false,
-            "low_flow": 410266,
-            "high_flow": 1896262,
+            "low_flow": 307700,
+            "high_flow": 2275514,
             "network_to_id": "3629097",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2549,9 +6000,7 @@
                     "overlap": 1135
                 }
             ],
-            "eclipsed_reaches": [
-                "3629087"
-            ]
+            "eclipsed_reaches": []
         },
         "3629083": {
             "us_xs": {
@@ -2569,9 +6018,10 @@
                 "xs_id": 156.52
             },
             "eclipsed": false,
-            "low_flow": 410260,
-            "high_flow": 1896429,
+            "low_flow": 307695,
+            "high_flow": 2275714,
             "network_to_id": "3629089",
+            "ds_slope": 7.000000186963007e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2611,19 +6061,7 @@
                     "overlap": 41
                 }
             ],
-            "eclipsed_reaches": [
-                "3629085",
-                "3627029",
-                "3627019",
-                "3626971",
-                "3629093"
-            ]
-        },
-        "3629077": {
-            "eclipsed": true,
-            "low_flow": 410264,
-            "high_flow": 1896906,
-            "network_to_id": "3629083"
+            "eclipsed_reaches": []
         },
         "3629073": {
             "us_xs": {
@@ -2641,9 +6079,10 @@
                 "xs_id": 158.67
             },
             "eclipsed": false,
-            "low_flow": 410262,
-            "high_flow": 1896903,
+            "low_flow": 307696,
+            "high_flow": 2276284,
             "network_to_id": "3629077",
+            "ds_slope": 3.9999998989515007e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2684,14 +6123,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "3629077",
-                "3626959",
-                "3626933",
-                "3629079",
-                "3626879",
-                "3629075",
-                "3626977",
-                "3628921"
+                "3629077"
             ]
         },
         "3629067": {
@@ -2710,9 +6142,10 @@
                 "xs_id": 162.99
             },
             "eclipsed": false,
-            "low_flow": 406724,
-            "high_flow": 1935829,
+            "low_flow": 305043,
+            "high_flow": 2322995,
             "network_to_id": "3629071",
+            "ds_slope": 0.00022000000171829015,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2752,13 +6185,7 @@
                     "overlap": 886
                 }
             ],
-            "eclipsed_reaches": [
-                "3629069",
-                "3628897",
-                "3626757",
-                "3626719",
-                "3626707"
-            ]
+            "eclipsed_reaches": []
         },
         "3629071": {
             "us_xs": {
@@ -2776,9 +6203,10 @@
                 "xs_id": 160.71
             },
             "eclipsed": false,
-            "low_flow": 406704,
-            "high_flow": 1935536,
+            "low_flow": 305028,
+            "high_flow": 2322643,
             "network_to_id": "3629073",
+            "ds_slope": 1.9999999494757503e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2818,19 +6246,7 @@
                     "overlap": 374
                 }
             ],
-            "eclipsed_reaches": [
-                "3629315",
-                "3626833",
-                "3626887",
-                "3626865",
-                "3626915",
-                "3626891",
-                "3626861",
-                "3626875",
-                "3626873",
-                "5066809",
-                "5052591"
-            ]
+            "eclipsed_reaches": []
         },
         "3629065": {
             "us_xs": {
@@ -2848,9 +6264,10 @@
                 "xs_id": 165.25
             },
             "eclipsed": false,
-            "low_flow": 406718,
-            "high_flow": 1936056,
+            "low_flow": 305038,
+            "high_flow": 2323267,
             "network_to_id": "3629067",
+            "ds_slope": 4.999999873689376e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2890,11 +6307,7 @@
                     "overlap": 2119
                 }
             ],
-            "eclipsed_reaches": [
-                "3629273",
-                "3629063",
-                "3626675"
-            ]
+            "eclipsed_reaches": []
         },
         "3624747": {
             "us_xs": {
@@ -2912,9 +6325,10 @@
                 "xs_id": 169.79
             },
             "eclipsed": false,
-            "low_flow": 406690,
-            "high_flow": 1936295,
+            "low_flow": 305017,
+            "high_flow": 2323555,
             "network_to_id": "3629053",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2954,11 +6368,7 @@
                     "overlap": 55
                 }
             ],
-            "eclipsed_reaches": [
-                "3624605",
-                "3626599",
-                "3624603"
-            ]
+            "eclipsed_reaches": []
         },
         "3629055": {
             "us_xs": {
@@ -2976,9 +6386,10 @@
                 "xs_id": 168.13
             },
             "eclipsed": false,
-            "low_flow": 406692,
-            "high_flow": 1936278,
+            "low_flow": 305019,
+            "high_flow": 2323533,
             "network_to_id": "3629059",
+            "ds_slope": 0.0001900000061141327,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3018,9 +6429,7 @@
                     "overlap": 1628
                 }
             ],
-            "eclipsed_reaches": [
-                "3629057"
-            ]
+            "eclipsed_reaches": []
         },
         "3629053": {
             "us_xs": {
@@ -3038,9 +6447,10 @@
                 "xs_id": 168.92
             },
             "eclipsed": false,
-            "low_flow": 406691,
-            "high_flow": 1936304,
+            "low_flow": 305018,
+            "high_flow": 2323565,
             "network_to_id": "3629055",
+            "ds_slope": 0.0012199999764561653,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3080,10 +6490,7 @@
                     "overlap": 873
                 }
             ],
-            "eclipsed_reaches": [
-                "3629271",
-                "3629051"
-            ]
+            "eclipsed_reaches": []
         },
         "3629059": {
             "us_xs": {
@@ -3101,9 +6508,10 @@
                 "xs_id": 167.52
             },
             "eclipsed": false,
-            "low_flow": 406713,
-            "high_flow": 1936231,
+            "low_flow": 305035,
+            "high_flow": 2323477,
             "network_to_id": "3629065",
+            "ds_slope": 0.00013000000035390258,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3161,9 +6569,10 @@
                 "xs_id": 171.46
             },
             "eclipsed": false,
-            "low_flow": 406671,
-            "high_flow": 1936382,
+            "low_flow": 305003,
+            "high_flow": 2323658,
             "network_to_id": "3624747",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3203,9 +6612,7 @@
                     "overlap": 844
                 }
             ],
-            "eclipsed_reaches": [
-                "3624743"
-            ]
+            "eclipsed_reaches": []
         },
         "3624739": {
             "us_xs": {
@@ -3223,9 +6630,10 @@
                 "xs_id": 171.88
             },
             "eclipsed": false,
-            "low_flow": 406287,
-            "high_flow": 1935839,
+            "low_flow": 304715,
+            "high_flow": 2323007,
             "network_to_id": "3624745",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3265,9 +6673,7 @@
                     "overlap": 385
                 }
             ],
-            "eclipsed_reaches": [
-                "3624741"
-            ]
+            "eclipsed_reaches": []
         },
         "3624735": {
             "us_xs": {
@@ -3285,9 +6691,10 @@
                 "xs_id": 174.0
             },
             "eclipsed": false,
-            "low_flow": 406180,
-            "high_flow": 1935727,
+            "low_flow": 304635,
+            "high_flow": 2322873,
             "network_to_id": "3624739",
+            "ds_slope": 1.9999999494757503e-05,
             "gage": "07010000",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07010000&legacy=1",
             "metrics": {
@@ -3329,11 +6736,7 @@
                     "overlap": 66
                 }
             ],
-            "eclipsed_reaches": [
-                "3624461",
-                "3624733",
-                "3624439"
-            ]
+            "eclipsed_reaches": []
         },
         "3629187": {
             "us_xs": {
@@ -3351,9 +6754,10 @@
                 "xs_id": 137.03
             },
             "eclipsed": false,
-            "low_flow": 410328,
-            "high_flow": 1894002,
+            "low_flow": 307746,
+            "high_flow": 2272802,
             "network_to_id": "3629191",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3394,18 +6798,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "3627763",
-                "3628997",
-                "3629191",
-                "3628023",
-                "3629321",
-                "3627951",
-                "3628087",
-                "3629189",
-                "3629015",
-                "3629281",
-                "3629193",
-                "3629323"
+                "3629191"
             ]
         },
         "3629181": {
@@ -3424,9 +6817,10 @@
                 "xs_id": 139.01
             },
             "eclipsed": false,
-            "low_flow": 410340,
-            "high_flow": 1894136,
+            "low_flow": 307755,
+            "high_flow": 2272963,
             "network_to_id": "3629319",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3450,18 +6844,19 @@
                         "max": 208
                     }
                 },
-                "lengths": null,
-                "coverage": null
+                "lengths": {
+                    "ras": 8117,
+                    "network": null,
+                    "network_to_ras_ratio": null
+                },
+                "coverage": {
+                    "start": 0.03,
+                    "end": 0.03
+                }
             },
             "overlapped_reaches": [],
             "eclipsed_reaches": [
-                "3629317",
-                "3627815",
-                "3627965",
-                "3629185",
-                "3627813",
                 "3629319",
-                "3629179",
                 "3629183"
             ]
         },
@@ -3481,9 +6876,10 @@
                 "xs_id": 140.47
             },
             "eclipsed": false,
-            "low_flow": 410346,
-            "high_flow": 1894342,
+            "low_flow": 307759,
+            "high_flow": 2273211,
             "network_to_id": "3629181",
+            "ds_slope": 1.9999999494757503e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3523,20 +6919,7 @@
                     "overlap": 202
                 }
             ],
-            "eclipsed_reaches": [
-                "3627759",
-                "3628993",
-                "3627877",
-                "3627783",
-                "3627769",
-                "3627845",
-                "3629175",
-                "3629177",
-                "3628979",
-                "3628985",
-                "3627735",
-                "3627557"
-            ]
+            "eclipsed_reaches": []
         },
         "3629163": {
             "us_xs": {
@@ -3554,9 +6937,10 @@
                 "xs_id": 143.8
             },
             "eclipsed": false,
-            "low_flow": 410393,
-            "high_flow": 1895150,
+            "low_flow": 307795,
+            "high_flow": 2274180,
             "network_to_id": "3629173",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3596,17 +6980,7 @@
                     "overlap": 747
                 }
             ],
-            "eclipsed_reaches": [
-                "3627651",
-                "3629165",
-                "3629167"
-            ]
-        },
-        "3629319": {
-            "eclipsed": true,
-            "low_flow": 410340,
-            "high_flow": 1894197,
-            "network_to_id": "3629183"
+            "eclipsed_reaches": []
         },
         "3634823": {
             "us_xs": {
@@ -3624,9 +6998,10 @@
                 "xs_id": 184.56
             },
             "eclipsed": false,
-            "low_flow": 406195,
-            "high_flow": 1940653,
+            "low_flow": 304646,
+            "high_flow": 2328784,
             "network_to_id": "3624723",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3641,12 +7016,12 @@
                     },
                     "thalweg_offset": {
                         "count": 5,
-                        "mean": 483,
-                        "std": 242,
-                        "min": 215,
-                        "25%": 389,
-                        "50%": 416,
-                        "75%": 527,
+                        "mean": 554,
+                        "std": 190,
+                        "min": 389,
+                        "25%": 416,
+                        "50%": 527,
+                        "75%": 569,
                         "max": 866
                     }
                 },
@@ -3666,19 +7041,7 @@
                     "overlap": 2370
                 }
             ],
-            "eclipsed_reaches": [
-                "3624787",
-                "3634871",
-                "3624775",
-                "3624777",
-                "3624779"
-            ]
-        },
-        "3629183": {
-            "eclipsed": true,
-            "low_flow": 410340,
-            "high_flow": 1894238,
-            "network_to_id": "3629187"
+            "eclipsed_reaches": []
         },
         "2927567": {
             "us_xs": {
@@ -3696,9 +7059,10 @@
                 "xs_id": 300.04
             },
             "eclipsed": false,
-            "low_flow": 171366,
-            "high_flow": 772535,
+            "low_flow": 128524,
+            "high_flow": 927042,
             "network_to_id": "2927571",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3739,16 +7103,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2927571",
-                "2927573",
-                "2927569"
+                "2927571"
             ]
-        },
-        "2927571": {
-            "eclipsed": true,
-            "low_flow": 171366,
-            "high_flow": 772540,
-            "network_to_id": "2927581"
         },
         "2927691": {
             "us_xs": {
@@ -3766,9 +7122,10 @@
                 "xs_id": 290.2
             },
             "eclipsed": false,
-            "low_flow": 171356,
-            "high_flow": 772341,
+            "low_flow": 128517,
+            "high_flow": 926809,
             "network_to_id": "2927819",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3808,9 +7165,7 @@
                     "overlap": 1682
                 }
             ],
-            "eclipsed_reaches": [
-                "2926987"
-            ]
+            "eclipsed_reaches": []
         },
         "2927597": {
             "us_xs": {
@@ -3828,9 +7183,10 @@
                 "xs_id": 293.86
             },
             "eclipsed": false,
-            "low_flow": 171360,
-            "high_flow": 772435,
+            "low_flow": 128520,
+            "high_flow": 926922,
             "network_to_id": "2927699",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3870,22 +7226,7 @@
                     "overlap": 697
                 }
             ],
-            "eclipsed_reaches": [
-                "2927637",
-                "2926943"
-            ]
-        },
-        "2927711": {
-            "eclipsed": true,
-            "low_flow": 171361,
-            "high_flow": 772423,
-            "network_to_id": "2927597"
-        },
-        "2927727": {
-            "eclipsed": true,
-            "low_flow": 171364,
-            "high_flow": 772472,
-            "network_to_id": "2927713"
+            "eclipsed_reaches": []
         },
         "2927713": {
             "us_xs": {
@@ -3903,9 +7244,10 @@
                 "xs_id": 294.55
             },
             "eclipsed": false,
-            "low_flow": 171361,
-            "high_flow": 772434,
+            "low_flow": 128520,
+            "high_flow": 926921,
             "network_to_id": "2927711",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3946,12 +7288,6 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2926911",
-                "2927729",
-                "2927593",
-                "2926879",
-                "2926881",
-                "2926905",
                 "2927711"
             ]
         },
@@ -3971,9 +7307,10 @@
                 "xs_id": 293.37
             },
             "eclipsed": false,
-            "low_flow": 171360,
-            "high_flow": 772404,
+            "low_flow": 128520,
+            "high_flow": 926885,
             "network_to_id": "2927601",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4015,12 +7352,6 @@
             ],
             "eclipsed_reaches": []
         },
-        "2927697": {
-            "eclipsed": true,
-            "low_flow": 171359,
-            "high_flow": 772378,
-            "network_to_id": "2927689"
-        },
         "2927689": {
             "us_xs": {
                 "river": "Mississippi",
@@ -4037,9 +7368,10 @@
                 "xs_id": 290.6
             },
             "eclipsed": false,
-            "low_flow": 171356,
-            "high_flow": 772334,
+            "low_flow": 128517,
+            "high_flow": 926800,
             "network_to_id": "2927691",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4079,15 +7411,7 @@
                     "overlap": 206
                 }
             ],
-            "eclipsed_reaches": [
-                "2927053",
-                "2927707",
-                "2927823",
-                "2927703",
-                "2927705",
-                "2926891",
-                "2926971"
-            ]
+            "eclipsed_reaches": []
         },
         "2927819": {
             "us_xs": {
@@ -4105,9 +7429,10 @@
                 "xs_id": 289.49
             },
             "eclipsed": false,
-            "low_flow": 171355,
-            "high_flow": 772322,
+            "low_flow": 128516,
+            "high_flow": 926786,
             "network_to_id": "2927611",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4147,18 +7472,7 @@
                     "overlap": 1643
                 }
             ],
-            "eclipsed_reaches": [
-                "2927069",
-                "2927821",
-                "2926925",
-                "937110032",
-                "937110075",
-                "2927673",
-                "2927671",
-                "937110030",
-                "937110031",
-                "937110034"
-            ]
+            "eclipsed_reaches": []
         },
         "2927589": {
             "us_xs": {
@@ -4176,9 +7490,10 @@
                 "xs_id": 296.15
             },
             "eclipsed": false,
-            "low_flow": 171364,
-            "high_flow": 772473,
+            "low_flow": 128523,
+            "high_flow": 926968,
             "network_to_id": "2927727",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4219,31 +7534,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2927579",
-                "2927587",
-                "2927585",
-                "2927731",
-                "2927735",
-                "2926819",
-                "937110100",
-                "2927577",
-                "2926817",
-                "2927565",
-                "2926825",
-                "2926827",
-                "2926829",
-                "2926807",
-                "2926805",
-                "2926777",
-                "2926781",
-                "2926689",
-                "2926831",
-                "2927739",
-                "2927743",
-                "2927733",
-                "2927727",
-                "937110101",
-                "937110102"
+                "2927727"
             ]
         },
         "2927601": {
@@ -4262,9 +7553,10 @@
                 "xs_id": 292.57
             },
             "eclipsed": false,
-            "low_flow": 171360,
-            "high_flow": 772386,
+            "low_flow": 128520,
+            "high_flow": 926863,
             "network_to_id": "2927697",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4305,12 +7597,6 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2927719",
-                "2927033",
-                "2927603",
-                "2927031",
-                "2926935",
-                "2927715",
                 "2927697"
             ]
         },
@@ -4330,9 +7616,10 @@
                 "xs_id": 297.81
             },
             "eclipsed": false,
-            "low_flow": 171366,
-            "high_flow": 772496,
+            "low_flow": 128524,
+            "high_flow": 926995,
             "network_to_id": "2927589",
+            "ds_slope": 0.0003000000142492354,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4372,17 +7659,7 @@
                     "overlap": 1833
                 }
             ],
-            "eclipsed_reaches": [
-                "2927813",
-                "2927815",
-                "2927583",
-                "2926793",
-                "2926803",
-                "2926811",
-                "2926809",
-                "2926799",
-                "2927737"
-            ]
+            "eclipsed_reaches": []
         },
         "2932183": {
             "us_xs": {
@@ -4400,9 +7677,10 @@
                 "xs_id": 279.63
             },
             "eclipsed": false,
-            "low_flow": 172161,
-            "high_flow": 783905,
+            "low_flow": 129121,
+            "high_flow": 940686,
             "network_to_id": "2930505",
+            "ds_slope": 1.9999999494757503e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4442,10 +7720,7 @@
                     "overlap": 423
                 }
             ],
-            "eclipsed_reaches": [
-                "2928933",
-                "2930487"
-            ]
+            "eclipsed_reaches": []
         },
         "2930505": {
             "us_xs": {
@@ -4463,9 +7738,10 @@
                 "xs_id": 279.08
             },
             "eclipsed": false,
-            "low_flow": 172161,
-            "high_flow": 783896,
+            "low_flow": 129120,
+            "high_flow": 940676,
             "network_to_id": "2931037",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4505,12 +7781,7 @@
                     "overlap": 2679
                 }
             ],
-            "eclipsed_reaches": [
-                "2929009",
-                "2929023",
-                "2930497",
-                "2929003"
-            ]
+            "eclipsed_reaches": []
         },
         "2932177": {
             "us_xs": {
@@ -4528,9 +7799,10 @@
                 "xs_id": 280.18
             },
             "eclipsed": false,
-            "low_flow": 172157,
-            "high_flow": 783981,
+            "low_flow": 129118,
+            "high_flow": 940777,
             "network_to_id": "2932183",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4570,22 +7842,7 @@
                     "overlap": 2250
                 }
             ],
-            "eclipsed_reaches": [
-                "2932181",
-                "2932179",
-                "2928969",
-                "2928957",
-                "2928897",
-                "2928883",
-                "2928881",
-                "2928903",
-                "2928961",
-                "2928963",
-                "2932227",
-                "2932225",
-                "2931649",
-                "2928835"
-            ]
+            "eclipsed_reaches": []
         },
         "2932173": {
             "us_xs": {
@@ -4603,9 +7860,10 @@
                 "xs_id": 282.09
             },
             "eclipsed": false,
-            "low_flow": 172149,
-            "high_flow": 784022,
+            "low_flow": 129112,
+            "high_flow": 940826,
             "network_to_id": "2932177",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4645,17 +7903,7 @@
                     "overlap": 146
                 }
             ],
-            "eclipsed_reaches": [
-                "2932175",
-                "2924243",
-                "2928823",
-                "2924287",
-                "2924371",
-                "2928821",
-                "2924285",
-                "937110061",
-                "2932169"
-            ]
+            "eclipsed_reaches": []
         },
         "2927615": {
             "us_xs": {
@@ -4673,9 +7921,10 @@
                 "xs_id": 286.17
             },
             "eclipsed": false,
-            "low_flow": 171353,
-            "high_flow": 772268,
+            "low_flow": 128514,
+            "high_flow": 926721,
             "network_to_id": "2932155",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4715,12 +7964,7 @@
                     "overlap": 1674
                 }
             ],
-            "eclipsed_reaches": [
-                "2927089",
-                "2927617",
-                "4869879",
-                "2931627"
-            ]
+            "eclipsed_reaches": []
         },
         "2932155": {
             "us_xs": {
@@ -4738,9 +7982,10 @@
                 "xs_id": 285.59
             },
             "eclipsed": false,
-            "low_flow": 171353,
-            "high_flow": 772270,
+            "low_flow": 128515,
+            "high_flow": 926724,
             "network_to_id": "2932159",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4780,22 +8025,7 @@
                     "overlap": 2603
                 }
             ],
-            "eclipsed_reaches": [
-                "2927093",
-                "4868429",
-                "4869787",
-                "4869789",
-                "4869793",
-                "4868433",
-                "4868431",
-                "4869791",
-                "2932205",
-                "2932201",
-                "2931631",
-                "2932203",
-                "2931637",
-                "2932207"
-            ]
+            "eclipsed_reaches": []
         },
         "2927645": {
             "us_xs": {
@@ -4813,9 +8043,10 @@
                 "xs_id": 286.72
             },
             "eclipsed": false,
-            "low_flow": 171353,
-            "high_flow": 772283,
+            "low_flow": 128515,
+            "high_flow": 926740,
             "network_to_id": "2927615",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4855,16 +8086,7 @@
                     "overlap": 1400
                 }
             ],
-            "eclipsed_reaches": [
-                "2927111",
-                "2927659",
-                "2927091",
-                "2927657",
-                "4869857",
-                "4869781",
-                "25897675",
-                "4869875"
-            ]
+            "eclipsed_reaches": []
         },
         "2927667": {
             "us_xs": {
@@ -4882,9 +8104,10 @@
                 "xs_id": 287.89
             },
             "eclipsed": false,
-            "low_flow": 171355,
-            "high_flow": 772284,
+            "low_flow": 128516,
+            "high_flow": 926741,
             "network_to_id": "2927647",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -4924,31 +8147,7 @@
                     "overlap": 3652
                 }
             ],
-            "eclipsed_reaches": [
-                "4869761",
-                "4867289",
-                "4868301",
-                "4868309",
-                "4867287",
-                "4869863",
-                "4869869",
-                "4869861",
-                "4869867",
-                "4869865",
-                "4869871",
-                "4869887",
-                "2927085",
-                "2927055",
-                "2927655",
-                "2927677",
-                "2927067",
-                "2927037",
-                "2927039",
-                "2927047",
-                "2927653",
-                "2927065",
-                "2927057"
-            ]
+            "eclipsed_reaches": []
         },
         "2927611": {
             "us_xs": {
@@ -4966,9 +8165,10 @@
                 "xs_id": 288.87
             },
             "eclipsed": false,
-            "low_flow": 171356,
-            "high_flow": 772311,
+            "low_flow": 128517,
+            "high_flow": 926773,
             "network_to_id": "2927613",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5009,22 +8209,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2927679",
-                "2927013",
-                "2927015",
-                "2927401",
-                "2927669",
-                "2927613",
-                "2938533",
-                "2927693",
-                "2927605"
+                "2927613"
             ]
-        },
-        "2927613": {
-            "eclipsed": true,
-            "low_flow": 171356,
-            "high_flow": 772310,
-            "network_to_id": "2927667"
         },
         "2927647": {
             "us_xs": {
@@ -5042,9 +8228,10 @@
                 "xs_id": 287.31
             },
             "eclipsed": false,
-            "low_flow": 171353,
-            "high_flow": 772283,
+            "low_flow": 128515,
+            "high_flow": 926740,
             "network_to_id": "2927645",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5084,16 +8271,7 @@
                     "overlap": 1281
                 }
             ],
-            "eclipsed_reaches": [
-                "4867285",
-                "4867731",
-                "4868349",
-                "2927663",
-                "2927665",
-                "4867251",
-                "4867811",
-                "4867813"
-            ]
+            "eclipsed_reaches": []
         },
         "2931037": {
             "us_xs": {
@@ -5111,9 +8289,10 @@
                 "xs_id": 278.67
             },
             "eclipsed": false,
-            "low_flow": 172161,
-            "high_flow": 783884,
+            "low_flow": 129121,
+            "high_flow": 940661,
             "network_to_id": "2930867",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5153,10 +8332,7 @@
                     "overlap": 614
                 }
             ],
-            "eclipsed_reaches": [
-                "2928959",
-                "2928953"
-            ]
+            "eclipsed_reaches": []
         },
         "2932159": {
             "us_xs": {
@@ -5174,9 +8350,10 @@
                 "xs_id": 285.0
             },
             "eclipsed": false,
-            "low_flow": 171353,
-            "high_flow": 772255,
+            "low_flow": 128515,
+            "high_flow": 926706,
             "network_to_id": "2932231",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5217,23 +8394,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2932231",
-                "2932163",
-                "2932237",
-                "2931641",
-                "2932161",
-                "2931643",
-                "2932233",
-                "2932213",
-                "2932215",
-                "2932217"
+                "2932231"
             ]
-        },
-        "2932231": {
-            "eclipsed": true,
-            "low_flow": 171353,
-            "high_flow": 772268,
-            "network_to_id": "2932165"
         },
         "2932171": {
             "us_xs": {
@@ -5251,9 +8413,10 @@
                 "xs_id": 283.75
             },
             "eclipsed": false,
-            "low_flow": 171352,
-            "high_flow": 772250,
+            "low_flow": 128514,
+            "high_flow": 926700,
             "network_to_id": "2932173",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5293,17 +8456,7 @@
                     "overlap": 1751
                 }
             ],
-            "eclipsed_reaches": [
-                "2931621",
-                "2931623",
-                "4872015"
-            ]
-        },
-        "2932209": {
-            "eclipsed": true,
-            "low_flow": 171353,
-            "high_flow": 772276,
-            "network_to_id": "2932171"
+            "eclipsed_reaches": []
         },
         "2932165": {
             "us_xs": {
@@ -5321,9 +8474,10 @@
                 "xs_id": 284.4
             },
             "eclipsed": false,
-            "low_flow": 171353,
-            "high_flow": 772274,
+            "low_flow": 128515,
+            "high_flow": 926728,
             "network_to_id": "2932209",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5364,10 +8518,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2932211",
-                "2938517",
-                "2932209",
-                "2932223"
+                "2932209"
             ]
         },
         "2930531": {
@@ -5386,9 +8537,10 @@
                 "xs_id": 275.0
             },
             "eclipsed": false,
-            "low_flow": 172157,
-            "high_flow": 783796,
+            "low_flow": 129117,
+            "high_flow": 940555,
             "network_to_id": "2931035",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5428,12 +8580,7 @@
                     "overlap": 1188
                 }
             ],
-            "eclipsed_reaches": [
-                "2930995",
-                "2929105",
-                "2929091",
-                "2930993"
-            ]
+            "eclipsed_reaches": []
         },
         "2930511": {
             "us_xs": {
@@ -5451,9 +8598,10 @@
                 "xs_id": 276.86
             },
             "eclipsed": false,
-            "low_flow": 172160,
-            "high_flow": 783856,
+            "low_flow": 129120,
+            "high_flow": 940627,
             "network_to_id": "2930871",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5493,14 +8641,7 @@
                     "overlap": 4052
                 }
             ],
-            "eclipsed_reaches": [
-                "2930809",
-                "2930519",
-                "2929067",
-                "2930509",
-                "2930777",
-                "2930811"
-            ]
+            "eclipsed_reaches": []
         },
         "2930871": {
             "us_xs": {
@@ -5518,9 +8659,10 @@
                 "xs_id": 275.55
             },
             "eclipsed": false,
-            "low_flow": 172157,
-            "high_flow": 783813,
+            "low_flow": 129117,
+            "high_flow": 940575,
             "network_to_id": "2930531",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5560,10 +8702,7 @@
                     "overlap": 1167
                 }
             ],
-            "eclipsed_reaches": [
-                "2930535",
-                "2930385"
-            ]
+            "eclipsed_reaches": []
         },
         "2930875": {
             "us_xs": {
@@ -5581,9 +8720,10 @@
                 "xs_id": 273.53
             },
             "eclipsed": false,
-            "low_flow": 172160,
-            "high_flow": 783750,
+            "low_flow": 129120,
+            "high_flow": 940500,
             "network_to_id": "2930553",
+            "ds_slope": 0.0006200000061653554,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5623,10 +8763,7 @@
                     "overlap": 994
                 }
             ],
-            "eclipsed_reaches": [
-                "2938519",
-                "2930525"
-            ]
+            "eclipsed_reaches": []
         },
         "2930553": {
             "us_xs": {
@@ -5644,9 +8781,10 @@
                 "xs_id": 273.32
             },
             "eclipsed": false,
-            "low_flow": 172160,
-            "high_flow": 783750,
+            "low_flow": 129120,
+            "high_flow": 940500,
             "network_to_id": "2930557",
+            "ds_slope": 0.003710000077262521,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5704,9 +8842,10 @@
                 "xs_id": 272.98
             },
             "eclipsed": false,
-            "low_flow": 172160,
-            "high_flow": 783751,
+            "low_flow": 129120,
+            "high_flow": 940501,
             "network_to_id": "2931045",
+            "ds_slope": 0.0013200000394135714,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5746,20 +8885,7 @@
                     "overlap": 1609
                 }
             ],
-            "eclipsed_reaches": [
-                "2938529",
-                "2930787",
-                "2929169",
-                "2930785",
-                "2930545",
-                "937110106",
-                "2930539",
-                "937110108",
-                "2930873",
-                "2930547",
-                "937110103",
-                "937110104"
-            ]
+            "eclipsed_reaches": []
         },
         "2930905": {
             "us_xs": {
@@ -5777,9 +8903,10 @@
                 "xs_id": 267.62
             },
             "eclipsed": false,
-            "low_flow": 172159,
-            "high_flow": 783614,
+            "low_flow": 129119,
+            "high_flow": 940337,
             "network_to_id": "2930907",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5820,17 +8947,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930895",
-                "2929299",
-                "2930903",
-                "2930897",
-                "2929277",
-                "2930893",
-                "2930891",
-                "2930907",
-                "2929263",
-                "2930561",
-                "2929261"
+                "2930907"
             ]
         },
         "2930909": {
@@ -5849,9 +8966,10 @@
                 "xs_id": 267.22
             },
             "eclipsed": false,
-            "low_flow": 172159,
-            "high_flow": 783625,
+            "low_flow": 129119,
+            "high_flow": 940350,
             "network_to_id": "2930569",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5892,21 +9010,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930901",
                 "2930569"
             ]
-        },
-        "2930569": {
-            "eclipsed": true,
-            "low_flow": 172159,
-            "high_flow": 783635,
-            "network_to_id": "2930577"
-        },
-        "2930907": {
-            "eclipsed": true,
-            "low_flow": 172159,
-            "high_flow": 783610,
-            "network_to_id": "2930909"
         },
         "2930577": {
             "us_xs": {
@@ -5924,9 +9029,10 @@
                 "xs_id": 265.59
             },
             "eclipsed": false,
-            "low_flow": 172156,
-            "high_flow": 783577,
+            "low_flow": 129117,
+            "high_flow": 940292,
             "network_to_id": "2930581",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -5966,23 +9072,7 @@
                     "overlap": 295
                 }
             ],
-            "eclipsed_reaches": [
-                "2930579",
-                "2930837",
-                "2929347",
-                "2930571",
-                "2929333",
-                "2929343",
-                "2929317",
-                "2930573",
-                "2930575"
-            ]
-        },
-        "2930543": {
-            "eclipsed": true,
-            "low_flow": 172158,
-            "high_flow": 783784,
-            "network_to_id": "2930875"
+            "eclipsed_reaches": []
         },
         "2930867": {
             "us_xs": {
@@ -6000,9 +9090,10 @@
                 "xs_id": 277.57
             },
             "eclipsed": false,
-            "low_flow": 172160,
-            "high_flow": 783868,
+            "low_flow": 129120,
+            "high_flow": 940642,
             "network_to_id": "2930511",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6042,13 +9133,7 @@
                     "overlap": 217
                 }
             ],
-            "eclipsed_reaches": [
-                "2928993",
-                "2930493",
-                "2930495",
-                "2930499",
-                "2930501"
-            ]
+            "eclipsed_reaches": []
         },
         "2931043": {
             "us_xs": {
@@ -6066,18 +9151,47 @@
                 "xs_id": 269.31
             },
             "eclipsed": false,
-            "low_flow": 172157,
-            "high_flow": 783623,
+            "low_flow": 129118,
+            "high_flow": 940347,
             "network_to_id": "2930887",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
-                "xs": null,
-                "lengths": null,
-                "coverage": null
+                "xs": {
+                    "centerline_offset": {
+                        "count": 1,
+                        "mean": 12,
+                        "std": -9999,
+                        "min": 12,
+                        "25%": 12,
+                        "50%": 12,
+                        "75%": 12,
+                        "max": 12
+                    },
+                    "thalweg_offset": {
+                        "count": 1,
+                        "mean": 115,
+                        "std": -9999,
+                        "min": 115,
+                        "25%": 115,
+                        "50%": 115,
+                        "75%": 115,
+                        "max": 115
+                    }
+                },
+                "lengths": {
+                    "ras": 3233,
+                    "network": null,
+                    "network_to_ras_ratio": null
+                },
+                "coverage": {
+                    "start": 0.8,
+                    "end": 0.8
+                }
             },
             "overlapped_reaches": [],
             "eclipsed_reaches": [
-                "2930565",
-                "2930887"
+                "2930887",
+                "2930565"
             ]
         },
         "2930559": {
@@ -6096,9 +9210,10 @@
                 "xs_id": 270.45
             },
             "eclipsed": false,
-            "low_flow": 172158,
-            "high_flow": 783661,
+            "low_flow": 129118,
+            "high_flow": 940394,
             "network_to_id": "2931041",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6138,9 +9253,7 @@
                     "overlap": 2649
                 }
             ],
-            "eclipsed_reaches": [
-                "2930563"
-            ]
+            "eclipsed_reaches": []
         },
         "2931041": {
             "us_xs": {
@@ -6158,9 +9271,10 @@
                 "xs_id": 269.91
             },
             "eclipsed": false,
-            "low_flow": 172158,
-            "high_flow": 783666,
+            "low_flow": 129118,
+            "high_flow": 940399,
             "network_to_id": "2931043",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6202,18 +9316,6 @@
             ],
             "eclipsed_reaches": []
         },
-        "2930889": {
-            "eclipsed": true,
-            "low_flow": 172159,
-            "high_flow": 783655,
-            "network_to_id": "2930905"
-        },
-        "2930565": {
-            "eclipsed": true,
-            "low_flow": 172159,
-            "high_flow": 783637,
-            "network_to_id": "2931051"
-        },
         "2931051": {
             "us_xs": {
                 "river": "Mississippi",
@@ -6230,9 +9332,10 @@
                 "xs_id": 268.76
             },
             "eclipsed": false,
-            "low_flow": 172159,
-            "high_flow": 783654,
+            "low_flow": 129119,
+            "high_flow": 940384,
             "network_to_id": "2930889",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6273,16 +9376,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930883",
-                "2930889",
-                "2930567"
+                "2930889"
             ]
-        },
-        "2930887": {
-            "eclipsed": true,
-            "low_flow": 172159,
-            "high_flow": 783622,
-            "network_to_id": "2930565"
         },
         "2931045": {
             "us_xs": {
@@ -6300,9 +9395,10 @@
                 "xs_id": 270.98
             },
             "eclipsed": false,
-            "low_flow": 172158,
-            "high_flow": 783658,
+            "low_flow": 129119,
+            "high_flow": 940389,
             "network_to_id": "2930559",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6342,15 +9438,7 @@
                     "overlap": 818
                 }
             ],
-            "eclipsed_reaches": [
-                "2929193",
-                "2929197",
-                "2929155",
-                "2929145",
-                "2929137",
-                "2930389",
-                "2929177"
-            ]
+            "eclipsed_reaches": []
         },
         "2931035": {
             "us_xs": {
@@ -6368,9 +9456,10 @@
                 "xs_id": 273.84
             },
             "eclipsed": false,
-            "low_flow": 172158,
-            "high_flow": 783778,
+            "low_flow": 129119,
+            "high_flow": 940534,
             "network_to_id": "2930543",
+            "ds_slope": 0.0005000000237487257,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6411,17 +9500,6 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930523",
-                "2930549",
-                "2930551",
-                "2929093",
-                "2929141",
-                "2929139",
-                "2930517",
-                "2929097",
-                "2930513",
-                "2929121",
-                "2930521",
                 "2930543"
             ]
         },
@@ -6441,9 +9519,10 @@
                 "xs_id": 237.56
             },
             "eclipsed": false,
-            "low_flow": 172243,
-            "high_flow": 777268,
+            "low_flow": 129182,
+            "high_flow": 932721,
             "network_to_id": "2932885",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6483,10 +9562,7 @@
                     "overlap": 479
                 }
             ],
-            "eclipsed_reaches": [
-                "2932879",
-                "2932909"
-            ]
+            "eclipsed_reaches": []
         },
         "2932885": {
             "us_xs": {
@@ -6504,9 +9580,10 @@
                 "xs_id": 237.0
             },
             "eclipsed": false,
-            "low_flow": 172243,
-            "high_flow": 777266,
+            "low_flow": 129182,
+            "high_flow": 932719,
             "network_to_id": "2932901",
+            "ds_slope": 0.0008200000156648457,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6546,17 +9623,15 @@
                     "overlap": 1384
                 }
             ],
-            "eclipsed_reaches": [
-                "2932883"
-            ]
+            "eclipsed_reaches": []
         },
         "2932869": {
             "us_xs": {
                 "river": "Mississippi",
                 "reach": "Reach 1",
-                "min_elevation": 399.49,
-                "max_elevation": 487.08,
-                "xs_id": 240.1
+                "min_elevation": 389.8,
+                "max_elevation": 493.29,
+                "xs_id": 240.64
             },
             "ds_xs": {
                 "river": "Mississippi",
@@ -6566,39 +9641,40 @@
                 "xs_id": 239.58
             },
             "eclipsed": false,
-            "low_flow": 172244,
-            "high_flow": 777285,
+            "low_flow": 129183,
+            "high_flow": 932742,
             "network_to_id": "2932905",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 2,
-                        "mean": 21,
-                        "std": 2,
-                        "min": 19,
-                        "25%": 20,
-                        "50%": 21,
+                        "count": 3,
+                        "mean": 14,
+                        "std": 11,
+                        "min": 1,
+                        "25%": 10,
+                        "50%": 19,
                         "75%": 21,
                         "max": 22
                     },
                     "thalweg_offset": {
-                        "count": 2,
-                        "mean": 87,
-                        "std": 105,
+                        "count": 3,
+                        "mean": 174,
+                        "std": 169,
                         "min": 12,
-                        "25%": 49,
-                        "50%": 87,
-                        "75%": 124,
-                        "max": 161
+                        "25%": 87,
+                        "50%": 161,
+                        "75%": 255,
+                        "max": 350
                     }
                 },
                 "lengths": {
-                    "ras": 2732,
-                    "network": 2726,
+                    "ras": 5564,
+                    "network": 5543,
                     "network_to_ras_ratio": 1.0
                 },
                 "coverage": {
-                    "start": 0.52,
+                    "start": 0.0,
                     "end": 1
                 }
             },
@@ -6608,27 +9684,7 @@
                     "overlap": 111
                 }
             ],
-            "eclipsed_reaches": [
-                "2932867"
-            ]
-        },
-        "2930771": {
-            "eclipsed": true,
-            "low_flow": 172246,
-            "high_flow": 777286,
-            "network_to_id": "2932865"
-        },
-        "2932865": {
-            "eclipsed": true,
-            "low_flow": 172246,
-            "high_flow": 777307,
-            "network_to_id": "2932869"
-        },
-        "2930761": {
-            "eclipsed": true,
-            "low_flow": 172244,
-            "high_flow": 777838,
-            "network_to_id": "2930763"
+            "eclipsed_reaches": []
         },
         "2930767": {
             "us_xs": {
@@ -6646,9 +9702,10 @@
                 "xs_id": 240.64
             },
             "eclipsed": false,
-            "low_flow": 172244,
-            "high_flow": 777828,
+            "low_flow": 129183,
+            "high_flow": 933393,
             "network_to_id": "2930771",
+            "ds_slope": 0.0006300000241026282,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6672,21 +9729,20 @@
                         "max": 34
                     }
                 },
-                "lengths": null,
-                "coverage": null
+                "lengths": {
+                    "ras": 3609,
+                    "network": null,
+                    "network_to_ras_ratio": null
+                },
+                "coverage": {
+                    "start": 0.38,
+                    "end": 0.38
+                }
             },
             "overlapped_reaches": [],
             "eclipsed_reaches": [
                 "2930771",
-                "2932865",
-                "2938527",
-                "2938523",
-                "2930769",
-                "2932725",
-                "2932863",
-                "2932703",
-                "2931085",
-                "2931087"
+                "2932865"
             ]
         },
         "2930763": {
@@ -6705,9 +9761,10 @@
                 "xs_id": 241.33
             },
             "eclipsed": false,
-            "low_flow": 172244,
-            "high_flow": 777839,
+            "low_flow": 129183,
+            "high_flow": 933407,
             "network_to_id": "2930767",
+            "ds_slope": 0.005510000046342611,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6734,7 +9791,7 @@
                 "lengths": {
                     "ras": 800,
                     "network": 788,
-                    "network_to_ras_ratio": 0.99
+                    "network_to_ras_ratio": 0.98
                 },
                 "coverage": {
                     "start": 0.9,
@@ -6748,12 +9805,6 @@
                 }
             ],
             "eclipsed_reaches": []
-        },
-        "2930625": {
-            "eclipsed": true,
-            "low_flow": 172258,
-            "high_flow": 777935,
-            "network_to_id": "2938449"
         },
         "2930607": {
             "us_xs": {
@@ -6771,9 +9822,10 @@
                 "xs_id": 256.95
             },
             "eclipsed": false,
-            "low_flow": 172260,
-            "high_flow": 777963,
+            "low_flow": 129195,
+            "high_flow": 933555,
             "network_to_id": "2938441",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6814,10 +9866,6 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2929645",
-                "2930997",
-                "2931001",
-                "2931003",
                 "2938441"
             ]
         },
@@ -6837,9 +9885,10 @@
                 "xs_id": 258.0
             },
             "eclipsed": false,
-            "low_flow": 172260,
-            "high_flow": 778010,
+            "low_flow": 129195,
+            "high_flow": 933612,
             "network_to_id": "2930603",
+            "ds_slope": 0.00039000000106170774,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6879,10 +9928,7 @@
                     "overlap": 730
                 }
             ],
-            "eclipsed_reaches": [
-                "2930599",
-                "2930597"
-            ]
+            "eclipsed_reaches": []
         },
         "2930593": {
             "us_xs": {
@@ -6900,9 +9946,10 @@
                 "xs_id": 258.72
             },
             "eclipsed": false,
-            "low_flow": 172232,
-            "high_flow": 778167,
+            "low_flow": 129174,
+            "high_flow": 933800,
             "network_to_id": "2930601",
+            "ds_slope": 0.0001500000071246177,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -6942,11 +9989,7 @@
                     "overlap": 499
                 }
             ],
-            "eclipsed_reaches": [
-                "2930595",
-                "2930425",
-                "2930913"
-            ]
+            "eclipsed_reaches": []
         },
         "2930981": {
             "us_xs": {
@@ -6964,9 +10007,10 @@
                 "xs_id": 244.67
             },
             "eclipsed": false,
-            "low_flow": 172250,
-            "high_flow": 777894,
+            "low_flow": 129187,
+            "high_flow": 933473,
             "network_to_id": "2930749",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7006,22 +10050,7 @@
                     "overlap": 1853
                 }
             ],
-            "eclipsed_reaches": [
-                "2931039",
-                "2930985",
-                "2930171",
-                "2930161",
-                "2930169",
-                "2930179",
-                "2930741",
-                "2930745",
-                "2930193",
-                "2930739",
-                "2930743",
-                "2930805",
-                "2930731",
-                "2930737"
-            ]
+            "eclipsed_reaches": []
         },
         "2930749": {
             "us_xs": {
@@ -7039,9 +10068,10 @@
                 "xs_id": 243.22
             },
             "eclipsed": false,
-            "low_flow": 172248,
-            "high_flow": 777905,
+            "low_flow": 129186,
+            "high_flow": 933486,
             "network_to_id": "2930759",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7081,15 +10111,7 @@
                     "overlap": 4006
                 }
             ],
-            "eclipsed_reaches": [
-                "2930789",
-                "2930229",
-                "2930747",
-                "2938531",
-                "2930215",
-                "2930209",
-                "2930987"
-            ]
+            "eclipsed_reaches": []
         },
         "2930759": {
             "us_xs": {
@@ -7107,9 +10129,10 @@
                 "xs_id": 241.49
             },
             "eclipsed": false,
-            "low_flow": 172244,
-            "high_flow": 777908,
+            "low_flow": 129183,
+            "high_flow": 933490,
             "network_to_id": "2930761",
+            "ds_slope": 7.999999797903001e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7150,17 +10173,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930761",
-                "2930311",
-                "2930477",
-                "2930265",
-                "2930313",
-                "2930273",
-                "2930279",
-                "2932707",
-                "2930753",
-                "2930757",
-                "2930755"
+                "2930761"
             ]
         },
         "2930639": {
@@ -7179,9 +10192,10 @@
                 "xs_id": 252.67
             },
             "eclipsed": false,
-            "low_flow": 172253,
-            "high_flow": 777933,
+            "low_flow": 129190,
+            "high_flow": 933520,
             "network_to_id": "2938505",
+            "ds_slope": 5.999999848427251e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7221,12 +10235,7 @@
                     "overlap": 921
                 }
             ],
-            "eclipsed_reaches": [
-                "2929889",
-                "2929901",
-                "2930861",
-                "2930641"
-            ]
+            "eclipsed_reaches": []
         },
         "2930603": {
             "us_xs": {
@@ -7244,9 +10253,10 @@
                 "xs_id": 257.57
             },
             "eclipsed": false,
-            "low_flow": 172260,
-            "high_flow": 777991,
+            "low_flow": 129195,
+            "high_flow": 933590,
             "network_to_id": "2930607",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7304,9 +10314,10 @@
                 "xs_id": 236.39
             },
             "eclipsed": false,
-            "low_flow": 172243,
-            "high_flow": 777262,
+            "low_flow": 129182,
+            "high_flow": 932715,
             "network_to_id": "2932893",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7346,15 +10357,7 @@
                     "overlap": 1608
                 }
             ],
-            "eclipsed_reaches": [
-                "2515899",
-                "2511445",
-                "2511065",
-                "2511465",
-                "2511443",
-                "2511463",
-                "2515907"
-            ]
+            "eclipsed_reaches": []
         },
         "2932905": {
             "us_xs": {
@@ -7372,9 +10375,10 @@
                 "xs_id": 238.59
             },
             "eclipsed": false,
-            "low_flow": 172244,
-            "high_flow": 777271,
+            "low_flow": 129183,
+            "high_flow": 932725,
             "network_to_id": "2932873",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7414,14 +10418,7 @@
                     "overlap": 1726
                 }
             ],
-            "eclipsed_reaches": [
-                "2932763",
-                "2932769",
-                "2932757",
-                "2932851",
-                "2932761",
-                "2932767"
-            ]
+            "eclipsed_reaches": []
         },
         "2930591": {
             "us_xs": {
@@ -7439,9 +10436,10 @@
                 "xs_id": 260.68
             },
             "eclipsed": false,
-            "low_flow": 172170,
-            "high_flow": 783235,
+            "low_flow": 129127,
+            "high_flow": 939882,
             "network_to_id": "2930593",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7481,16 +10479,7 @@
                     "overlap": 11
                 }
             ],
-            "eclipsed_reaches": [
-                "2938521",
-                "2930587"
-            ]
-        },
-        "2938441": {
-            "eclipsed": true,
-            "low_flow": 172260,
-            "high_flow": 777926,
-            "network_to_id": "2938445"
+            "eclipsed_reaches": []
         },
         "2938445": {
             "us_xs": {
@@ -7508,9 +10497,10 @@
                 "xs_id": 256.4
             },
             "eclipsed": false,
-            "low_flow": 172260,
-            "high_flow": 777945,
+            "low_flow": 129195,
+            "high_flow": 933535,
             "network_to_id": "2930621",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7550,22 +10540,7 @@
                     "overlap": 2826
                 }
             ],
-            "eclipsed_reaches": [
-                "2929661",
-                "2930919",
-                "2930923",
-                "2929701",
-                "2929707",
-                "2930617",
-                "2930611",
-                "2929665",
-                "2930613",
-                "2930827",
-                "2930921",
-                "2930845",
-                "2930917",
-                "2930615"
-            ]
+            "eclipsed_reaches": []
         },
         "2938449": {
             "us_xs": {
@@ -7583,9 +10558,10 @@
                 "xs_id": 254.68
             },
             "eclipsed": false,
-            "low_flow": 172258,
-            "high_flow": 777909,
+            "low_flow": 129193,
+            "high_flow": 933491,
             "network_to_id": "2930639",
+            "ds_slope": 0.0001500000071246177,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7625,20 +10601,7 @@
                     "overlap": 1961
                 }
             ],
-            "eclipsed_reaches": [
-                "2930849",
-                "2929757",
-                "2929735",
-                "2930629",
-                "2930627",
-                "2929753"
-            ]
-        },
-        "2938455": {
-            "eclipsed": true,
-            "low_flow": 172252,
-            "high_flow": 777939,
-            "network_to_id": "2930679"
+            "eclipsed_reaches": []
         },
         "2930651": {
             "us_xs": {
@@ -7656,9 +10619,10 @@
                 "xs_id": 250.38
             },
             "eclipsed": false,
-            "low_flow": 172252,
-            "high_flow": 777943,
+            "low_flow": 129189,
+            "high_flow": 933532,
             "network_to_id": "2938455",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7699,16 +10663,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2929985",
-                "2929983",
-                "2929973",
-                "2930667",
-                "2938455",
-                "2931059",
-                "2931067",
-                "2931071",
-                "937110039",
-                "937110040"
+                "2938455"
             ]
         },
         "2938461": {
@@ -7727,9 +10682,10 @@
                 "xs_id": 248.87
             },
             "eclipsed": false,
-            "low_flow": 172251,
-            "high_flow": 777930,
+            "low_flow": 129188,
+            "high_flow": 933516,
             "network_to_id": "2930705",
+            "ds_slope": 7.999999797903001e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7769,24 +10725,7 @@
                     "overlap": 2579
                 }
             ],
-            "eclipsed_reaches": [
-                "2930015",
-                "2930027",
-                "2930951",
-                "2930035",
-                "2930955",
-                "2930031",
-                "2931091",
-                "2930687",
-                "2930795",
-                "2930949",
-                "2931007",
-                "2930953",
-                "2930957",
-                "2931023",
-                "2931025",
-                "2930701"
-            ]
+            "eclipsed_reaches": []
         },
         "2930713": {
             "us_xs": {
@@ -7804,9 +10743,10 @@
                 "xs_id": 247.09
             },
             "eclipsed": false,
-            "low_flow": 172250,
-            "high_flow": 777893,
+            "low_flow": 129188,
+            "high_flow": 933472,
             "network_to_id": "2938477",
+            "ds_slope": 9.999999747378752e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7847,15 +10787,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2931077",
                 "2938477"
             ]
-        },
-        "2938477": {
-            "eclipsed": true,
-            "low_flow": 172251,
-            "high_flow": 777900,
-            "network_to_id": "2930719"
         },
         "2930709": {
             "us_xs": {
@@ -7873,9 +10806,10 @@
                 "xs_id": 247.69
             },
             "eclipsed": false,
-            "low_flow": 172251,
-            "high_flow": 777896,
+            "low_flow": 129188,
+            "high_flow": 933475,
             "network_to_id": "2930713",
+            "ds_slope": 0.00011999999696854502,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7915,18 +10849,7 @@
                     "overlap": 1988
                 }
             ],
-            "eclipsed_reaches": [
-                "2930063",
-                "2930061",
-                "2930053",
-                "2930055"
-            ]
-        },
-        "2931017": {
-            "eclipsed": true,
-            "low_flow": 172250,
-            "high_flow": 777881,
-            "network_to_id": "2930981"
+            "eclipsed_reaches": []
         },
         "2930723": {
             "us_xs": {
@@ -7944,9 +10867,10 @@
                 "xs_id": 246.0
             },
             "eclipsed": false,
-            "low_flow": 172250,
-            "high_flow": 777887,
+            "low_flow": 129188,
+            "high_flow": 933465,
             "network_to_id": "2931017",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -7987,16 +10911,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930133",
-                "2930729",
-                "2930135",
-                "2930727",
-                "2930807",
-                "2930725",
-                "2930801",
-                "2931017",
-                "937110045",
-                "937110046"
+                "2931017"
             ]
         },
         "2930649": {
@@ -8015,9 +10930,10 @@
                 "xs_id": 250.85
             },
             "eclipsed": false,
-            "low_flow": 172252,
-            "high_flow": 777954,
+            "low_flow": 129189,
+            "high_flow": 933545,
             "network_to_id": "2930651",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8057,19 +10973,7 @@
                     "overlap": 155
                 }
             ],
-            "eclipsed_reaches": [
-                "2929939",
-                "2930655",
-                "2930653",
-                "2929959",
-                "2930663",
-                "2929961",
-                "2931027",
-                "2931061",
-                "2931065",
-                "937110086",
-                "937110087"
-            ]
+            "eclipsed_reaches": []
         },
         "2938505": {
             "us_xs": {
@@ -8087,9 +10991,10 @@
                 "xs_id": 252.19
             },
             "eclipsed": false,
-            "low_flow": 172253,
-            "high_flow": 777942,
+            "low_flow": 129190,
+            "high_flow": 933531,
             "network_to_id": "2938507",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8129,9 +11034,7 @@
                     "overlap": 990
                 }
             ],
-            "eclipsed_reaches": [
-                "2930851"
-            ]
+            "eclipsed_reaches": []
         },
         "2938507": {
             "us_xs": {
@@ -8149,9 +11052,10 @@
                 "xs_id": 251.22
             },
             "eclipsed": false,
-            "low_flow": 172253,
-            "high_flow": 777944,
+            "low_flow": 129189,
+            "high_flow": 933533,
             "network_to_id": "2930649",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8191,36 +11095,7 @@
                     "overlap": 2176
                 }
             ],
-            "eclipsed_reaches": [
-                "2929929",
-                "2930939",
-                "2930937",
-                "2929935",
-                "2930947",
-                "2930943",
-                "2929909",
-                "2930933",
-                "2930929",
-                "2929995",
-                "2930855",
-                "2930931",
-                "2930935",
-                "2930941",
-                "2930831",
-                "2930833",
-                "2930945",
-                "937110084",
-                "937110085",
-                "937110050",
-                "937110049",
-                "2929879"
-            ]
-        },
-        "2932875": {
-            "eclipsed": true,
-            "low_flow": 172244,
-            "high_flow": 777291,
-            "network_to_id": "2932881"
+            "eclipsed_reaches": []
         },
         "2932873": {
             "us_xs": {
@@ -8238,9 +11113,10 @@
                 "xs_id": 238.19
             },
             "eclipsed": false,
-            "low_flow": 172243,
-            "high_flow": 777291,
+            "low_flow": 129182,
+            "high_flow": 932750,
             "network_to_id": "2932875",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8281,10 +11157,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2932887",
-                "2932871",
-                "2932875",
-                "2511025"
+                "2932875"
             ]
         },
         "2930719": {
@@ -8303,9 +11176,10 @@
                 "xs_id": 246.56
             },
             "eclipsed": false,
-            "low_flow": 172250,
-            "high_flow": 777902,
+            "low_flow": 129188,
+            "high_flow": 933483,
             "network_to_id": "2938485",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8346,28 +11220,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930717",
-                "2930089",
-                "2930111",
-                "2930721",
-                "2930969",
-                "937110055",
-                "937110059",
-                "2930975",
-                "2938485",
-                "2930117",
-                "2930977",
-                "2930971",
-                "2930101",
-                "937110083",
-                "937110057"
+                "2938485"
             ]
-        },
-        "2938485": {
-            "eclipsed": true,
-            "low_flow": 172250,
-            "high_flow": 777903,
-            "network_to_id": "2930723"
         },
         "2930705": {
             "us_xs": {
@@ -8385,9 +11239,10 @@
                 "xs_id": 248.22
             },
             "eclipsed": false,
-            "low_flow": 172250,
-            "high_flow": 777905,
+            "low_flow": 129188,
+            "high_flow": 933486,
             "network_to_id": "2930709",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8427,18 +11282,7 @@
                     "overlap": 100
                 }
             ],
-            "eclipsed_reaches": [
-                "2930043",
-                "2931013",
-                "2931015",
-                "2931011",
-                "2931019",
-                "2930703",
-                "2930049",
-                "2930965",
-                "2930961",
-                "2931021"
-            ]
+            "eclipsed_reaches": []
         },
         "2930679": {
             "us_xs": {
@@ -8456,9 +11300,10 @@
                 "xs_id": 250.0
             },
             "eclipsed": false,
-            "low_flow": 172252,
-            "high_flow": 777914,
+            "low_flow": 129189,
+            "high_flow": 933497,
             "network_to_id": "2938461",
+            "ds_slope": 3.9999998989515007e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8498,15 +11343,7 @@
                     "overlap": 723
                 }
             ],
-            "eclipsed_reaches": [
-                "2929979",
-                "2930669",
-                "2930819",
-                "2930671",
-                "2930673",
-                "2930817",
-                "2929981"
-            ]
+            "eclipsed_reaches": []
         },
         "2930621": {
             "us_xs": {
@@ -8524,9 +11361,10 @@
                 "xs_id": 255.26
             },
             "eclipsed": false,
-            "low_flow": 172258,
-            "high_flow": 777963,
+            "low_flow": 129194,
+            "high_flow": 933556,
             "network_to_id": "2930625",
+            "ds_slope": 3.9999998989515007e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8567,12 +11405,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "2930625",
-                "2929745",
-                "2929751",
-                "2930623",
-                "2930619",
-                "2930925"
+                "2930625"
             ]
         },
         "2938437": {
@@ -8591,9 +11424,10 @@
                 "xs_id": 261.41
             },
             "eclipsed": false,
-            "low_flow": 172171,
-            "high_flow": 783270,
+            "low_flow": 129128,
+            "high_flow": 939924,
             "network_to_id": "2930591",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8651,9 +11485,10 @@
                 "xs_id": 261.98
             },
             "eclipsed": false,
-            "low_flow": 172146,
-            "high_flow": 783334,
+            "low_flow": 129109,
+            "high_flow": 940001,
             "network_to_id": "2938437",
+            "ds_slope": 5.999999848427251e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8693,28 +11528,7 @@
                     "overlap": 873
                 }
             ],
-            "eclipsed_reaches": [
-                "2930417",
-                "2929427",
-                "2929497",
-                "2929423",
-                "2929493",
-                "2929433",
-                "2929445",
-                "2929457",
-                "2930415",
-                "2929389",
-                "2929469",
-                "2929495",
-                "2929473",
-                "2929447",
-                "2930421",
-                "2930583",
-                "2929395",
-                "2930911",
-                "2931029",
-                "27570634"
-            ]
+            "eclipsed_reaches": []
         },
         "2932893": {
             "us_xs": {
@@ -8732,9 +11546,10 @@
                 "xs_id": 235.79
             },
             "eclipsed": false,
-            "low_flow": 172242,
-            "high_flow": 777280,
+            "low_flow": 129181,
+            "high_flow": 932736,
             "network_to_id": "880776",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8774,9 +11589,7 @@
                     "overlap": 1339
                 }
             ],
-            "eclipsed_reaches": [
-                "880794"
-            ]
+            "eclipsed_reaches": []
         },
         "880614": {
             "us_xs": {
@@ -8794,9 +11607,10 @@
                 "xs_id": 233.11
             },
             "eclipsed": false,
-            "low_flow": 172242,
-            "high_flow": 777269,
+            "low_flow": 129181,
+            "high_flow": 932723,
             "network_to_id": "880624",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8854,9 +11668,10 @@
                 "xs_id": 232.58
             },
             "eclipsed": false,
-            "low_flow": 172241,
-            "high_flow": 777257,
+            "low_flow": 129181,
+            "high_flow": 932709,
             "network_to_id": "880820",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8914,9 +11729,10 @@
                 "xs_id": 235.16
             },
             "eclipsed": false,
-            "low_flow": 172242,
-            "high_flow": 777280,
+            "low_flow": 129181,
+            "high_flow": 932736,
             "network_to_id": "880784",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -8956,12 +11772,7 @@
                     "overlap": 929
                 }
             ],
-            "eclipsed_reaches": [
-                "2511415",
-                "880724",
-                "880592",
-                "882736"
-            ]
+            "eclipsed_reaches": []
         },
         "880596": {
             "us_xs": {
@@ -8979,9 +11790,10 @@
                 "xs_id": 222.1
             },
             "eclipsed": false,
-            "low_flow": 172419,
-            "high_flow": 782793,
+            "low_flow": 129314,
+            "high_flow": 939351,
             "network_to_id": "880548",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9021,19 +11833,7 @@
                     "overlap": 700
                 }
             ],
-            "eclipsed_reaches": [
-                "879816",
-                "880582",
-                "880594",
-                "880552",
-                "880590",
-                "3601824",
-                "3601986",
-                "879804",
-                "879876",
-                "880574",
-                "880576"
-            ]
+            "eclipsed_reaches": []
         },
         "880630": {
             "us_xs": {
@@ -9051,9 +11851,10 @@
                 "xs_id": 224.7
             },
             "eclipsed": false,
-            "low_flow": 172425,
-            "high_flow": 782853,
+            "low_flow": 129318,
+            "high_flow": 939423,
             "network_to_id": "880596",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9093,9 +11894,7 @@
                     "overlap": 543
                 }
             ],
-            "eclipsed_reaches": [
-                "880598"
-            ]
+            "eclipsed_reaches": []
         },
         "880654": {
             "us_xs": {
@@ -9113,9 +11912,10 @@
                 "xs_id": 225.7
             },
             "eclipsed": false,
-            "low_flow": 172426,
-            "high_flow": 782814,
+            "low_flow": 129319,
+            "high_flow": 939377,
             "network_to_id": "880630",
+            "ds_slope": 0.0002300000051036477,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9155,15 +11955,7 @@
                     "overlap": 2636
                 }
             ],
-            "eclipsed_reaches": [
-                "880772",
-                "879938",
-                "880400",
-                "880674",
-                "880632",
-                "879924",
-                "880658"
-            ]
+            "eclipsed_reaches": []
         },
         "880662": {
             "us_xs": {
@@ -9181,9 +11973,10 @@
                 "xs_id": 227.76
             },
             "eclipsed": false,
-            "low_flow": 172426,
-            "high_flow": 782842,
+            "low_flow": 129320,
+            "high_flow": 939410,
             "network_to_id": "880654",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9223,11 +12016,7 @@
                     "overlap": 537
                 }
             ],
-            "eclipsed_reaches": [
-                "879916",
-                "880672",
-                "880656"
-            ]
+            "eclipsed_reaches": []
         },
         "880820": {
             "us_xs": {
@@ -9245,9 +12034,10 @@
                 "xs_id": 232.01
             },
             "eclipsed": false,
-            "low_flow": 172431,
-            "high_flow": 782822,
+            "low_flow": 129323,
+            "high_flow": 939387,
             "network_to_id": "880640",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9305,9 +12095,10 @@
                 "xs_id": 228.29
             },
             "eclipsed": false,
-            "low_flow": 172427,
-            "high_flow": 782822,
+            "low_flow": 129320,
+            "high_flow": 939386,
             "network_to_id": "880662",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9347,13 +12138,7 @@
                     "overlap": 813
                 }
             ],
-            "eclipsed_reaches": [
-                "879980",
-                "879960",
-                "879966",
-                "882730",
-                "880660"
-            ]
+            "eclipsed_reaches": []
         },
         "880786": {
             "us_xs": {
@@ -9371,9 +12156,10 @@
                 "xs_id": 234.05
             },
             "eclipsed": false,
-            "low_flow": 172242,
-            "high_flow": 777261,
+            "low_flow": 129181,
+            "high_flow": 932714,
             "network_to_id": "880604",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9431,9 +12217,10 @@
                 "xs_id": 234.55
             },
             "eclipsed": false,
-            "low_flow": 172242,
-            "high_flow": 777268,
+            "low_flow": 129181,
+            "high_flow": 932722,
             "network_to_id": "880786",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9473,16 +12260,7 @@
                     "overlap": 2476
                 }
             ],
-            "eclipsed_reaches": [
-                "880760",
-                "882734",
-                "882732",
-                "879812",
-                "880804",
-                "880806",
-                "882698",
-                "882726"
-            ]
+            "eclipsed_reaches": []
         },
         "880640": {
             "us_xs": {
@@ -9500,9 +12278,10 @@
                 "xs_id": 231.4
             },
             "eclipsed": false,
-            "low_flow": 172430,
-            "high_flow": 782830,
+            "low_flow": 129323,
+            "high_flow": 939396,
             "network_to_id": "880644",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9543,16 +12322,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "880638",
-                "880642",
                 "880644"
             ]
-        },
-        "880644": {
-            "eclipsed": true,
-            "low_flow": 172430,
-            "high_flow": 782840,
-            "network_to_id": "880668"
         },
         "880668": {
             "us_xs": {
@@ -9570,9 +12341,10 @@
                 "xs_id": 229.0
             },
             "eclipsed": false,
-            "low_flow": 172427,
-            "high_flow": 782822,
+            "low_flow": 129320,
+            "high_flow": 939386,
             "network_to_id": "880818",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9612,12 +12384,7 @@
                     "overlap": 1243
                 }
             ],
-            "eclipsed_reaches": [
-                "879952",
-                "879964",
-                "879962",
-                "879954"
-            ]
+            "eclipsed_reaches": []
         },
         "880604": {
             "us_xs": {
@@ -9635,9 +12402,10 @@
                 "xs_id": 233.59
             },
             "eclipsed": false,
-            "low_flow": 172242,
-            "high_flow": 777272,
+            "low_flow": 129181,
+            "high_flow": 932727,
             "network_to_id": "880614",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9677,11 +12445,7 @@
                     "overlap": 1405
                 }
             ],
-            "eclipsed_reaches": [
-                "880602",
-                "879868",
-                "880756"
-            ]
+            "eclipsed_reaches": []
         },
         "880536": {
             "us_xs": {
@@ -9699,9 +12463,10 @@
                 "xs_id": 211.92
             },
             "eclipsed": false,
-            "low_flow": 245382,
-            "high_flow": 862345,
+            "low_flow": 184036,
+            "high_flow": 1034814,
             "network_to_id": "880544",
+            "ds_slope": 7.000000186963007e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9741,12 +12506,7 @@
                     "overlap": 2011
                 }
             ],
-            "eclipsed_reaches": [
-                "880538",
-                "879720",
-                "880540",
-                "880792"
-            ]
+            "eclipsed_reaches": []
         },
         "880816": {
             "us_xs": {
@@ -9764,9 +12524,10 @@
                 "xs_id": 218.86
             },
             "eclipsed": false,
-            "low_flow": 172618,
-            "high_flow": 784046,
+            "low_flow": 129463,
+            "high_flow": 940855,
             "network_to_id": "880494",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9806,25 +12567,7 @@
                     "overlap": 170
                 }
             ],
-            "eclipsed_reaches": [
-                "880500",
-                "880458",
-                "880462",
-                "880456",
-                "882682",
-                "880802",
-                "880460",
-                "880810",
-                "880464",
-                "3607100",
-                "3601938",
-                "3601996",
-                "3601944",
-                "3607074",
-                "3601958",
-                "3601960",
-                "3601962"
-            ]
+            "eclipsed_reaches": []
         },
         "880548": {
             "us_xs": {
@@ -9842,9 +12585,10 @@
                 "xs_id": 221.05
             },
             "eclipsed": false,
-            "low_flow": 172418,
-            "high_flow": 782797,
+            "low_flow": 129314,
+            "high_flow": 939356,
             "network_to_id": "880534",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9884,15 +12628,7 @@
                     "overlap": 1491
                 }
             ],
-            "eclipsed_reaches": [
-                "3601904"
-            ]
-        },
-        "880478": {
-            "eclipsed": true,
-            "low_flow": 245387,
-            "high_flow": 862351,
-            "network_to_id": "880484"
+            "eclipsed_reaches": []
         },
         "880484": {
             "us_xs": {
@@ -9910,9 +12646,10 @@
                 "xs_id": 216.55
             },
             "eclipsed": false,
-            "low_flow": 245386,
-            "high_flow": 862355,
+            "low_flow": 184040,
+            "high_flow": 1034826,
             "network_to_id": "880486",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -9952,10 +12689,7 @@
                     "overlap": 1157
                 }
             ],
-            "eclipsed_reaches": [
-                "879640",
-                "880482"
-            ]
+            "eclipsed_reaches": []
         },
         "880494": {
             "us_xs": {
@@ -9973,9 +12707,10 @@
                 "xs_id": 217.47
             },
             "eclipsed": false,
-            "low_flow": 172618,
-            "high_flow": 784064,
+            "low_flow": 129463,
+            "high_flow": 940877,
             "network_to_id": "880478",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10016,19 +12751,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "879796",
-                "879662",
-                "880514",
-                "879684",
-                "879686",
-                "880516",
-                "879708",
-                "880466",
-                "880470",
-                "880476",
-                "880478",
-                "880480",
-                "880472"
+                "880478"
             ]
         },
         "882686": {
@@ -10047,9 +12770,10 @@
                 "xs_id": 214.48
             },
             "eclipsed": false,
-            "low_flow": 245384,
-            "high_flow": 862330,
+            "low_flow": 184038,
+            "high_flow": 1034797,
             "network_to_id": "882688",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10109,9 +12833,10 @@
                 "xs_id": 220.47
             },
             "eclipsed": false,
-            "low_flow": 172621,
-            "high_flow": 784079,
+            "low_flow": 129466,
+            "high_flow": 940895,
             "network_to_id": "880816",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10151,10 +12876,7 @@
                     "overlap": 1172
                 }
             ],
-            "eclipsed_reaches": [
-                "3601988",
-                "3601802"
-            ]
+            "eclipsed_reaches": []
         },
         "24745881": {
             "us_xs": {
@@ -10172,9 +12894,10 @@
                 "xs_id": 210.13
             },
             "eclipsed": false,
-            "low_flow": 245384,
-            "high_flow": 862581,
+            "low_flow": 184038,
+            "high_flow": 1035097,
             "network_to_id": "880768",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10214,12 +12937,7 @@
                     "overlap": 1662
                 }
             ],
-            "eclipsed_reaches": [
-                "879770",
-                "880554",
-                "880558",
-                "880564"
-            ]
+            "eclipsed_reaches": []
         },
         "880544": {
             "us_xs": {
@@ -10237,9 +12955,10 @@
                 "xs_id": 210.79
             },
             "eclipsed": false,
-            "low_flow": 245384,
-            "high_flow": 862593,
+            "low_flow": 184038,
+            "high_flow": 1035111,
             "network_to_id": "24745881",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10279,10 +12998,7 @@
                     "overlap": 1140
                 }
             ],
-            "eclipsed_reaches": [
-                "880738",
-                "879776"
-            ]
+            "eclipsed_reaches": []
         },
         "880512": {
             "us_xs": {
@@ -10300,9 +13016,10 @@
                 "xs_id": 213.87
             },
             "eclipsed": false,
-            "low_flow": 245386,
-            "high_flow": 862402,
+            "low_flow": 184039,
+            "high_flow": 1034883,
             "network_to_id": "880536",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10342,20 +13059,7 @@
                     "overlap": 1176
                 }
             ],
-            "eclipsed_reaches": [
-                "879700",
-                "880510",
-                "880520",
-                "882722",
-                "880524",
-                "880522"
-            ]
-        },
-        "882688": {
-            "eclipsed": true,
-            "low_flow": 245386,
-            "high_flow": 862414,
-            "network_to_id": "880512"
+            "eclipsed_reaches": []
         },
         "880490": {
             "us_xs": {
@@ -10373,9 +13077,10 @@
                 "xs_id": 215.6
             },
             "eclipsed": false,
-            "low_flow": 245386,
-            "high_flow": 862322,
+            "low_flow": 184039,
+            "high_flow": 1034786,
             "network_to_id": "882686",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10415,10 +13120,7 @@
                     "overlap": 146
                 }
             ],
-            "eclipsed_reaches": [
-                "880488",
-                "880506"
-            ]
+            "eclipsed_reaches": []
         },
         "880486": {
             "us_xs": {
@@ -10436,9 +13138,10 @@
                 "xs_id": 215.99
             },
             "eclipsed": false,
-            "low_flow": 245386,
-            "high_flow": 862344,
+            "low_flow": 184039,
+            "high_flow": 1034813,
             "network_to_id": "880490",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10478,13 +13181,7 @@
                     "overlap": 1381
                 }
             ],
-            "eclipsed_reaches": [
-                "879692",
-                "879648",
-                "880498",
-                "24745901",
-                "880502"
-            ]
+            "eclipsed_reaches": []
         },
         "880666": {
             "us_xs": {
@@ -10502,9 +13199,10 @@
                 "xs_id": 197.71
             },
             "eclipsed": false,
-            "low_flow": 245432,
-            "high_flow": 852745,
+            "low_flow": 184074,
+            "high_flow": 1023294,
             "network_to_id": "882710",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10544,10 +13242,7 @@
                     "overlap": 630
                 }
             ],
-            "eclipsed_reaches": [
-                "879920",
-                "880664"
-            ]
+            "eclipsed_reaches": []
         },
         "880652": {
             "us_xs": {
@@ -10565,9 +13260,10 @@
                 "xs_id": 198.28
             },
             "eclipsed": false,
-            "low_flow": 245426,
-            "high_flow": 852690,
+            "low_flow": 184070,
+            "high_flow": 1023228,
             "network_to_id": "880666",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10607,10 +13303,7 @@
                     "overlap": 1085
                 }
             ],
-            "eclipsed_reaches": [
-                "880650",
-                "882728"
-            ]
+            "eclipsed_reaches": []
         },
         "880622": {
             "us_xs": {
@@ -10628,9 +13321,10 @@
                 "xs_id": 200.85
             },
             "eclipsed": false,
-            "low_flow": 245383,
-            "high_flow": 852328,
+            "low_flow": 184037,
+            "high_flow": 1022793,
             "network_to_id": "880636",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10670,10 +13364,7 @@
                     "overlap": 1037
                 }
             ],
-            "eclipsed_reaches": [
-                "880628",
-                "880726"
-            ]
+            "eclipsed_reaches": []
         },
         "880580": {
             "us_xs": {
@@ -10691,9 +13382,10 @@
                 "xs_id": 204.96
             },
             "eclipsed": false,
-            "low_flow": 245386,
-            "high_flow": 852434,
+            "low_flow": 184040,
+            "high_flow": 1022921,
             "network_to_id": "880606",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10708,13 +13400,13 @@
                     },
                     "thalweg_offset": {
                         "count": 4,
-                        "mean": 197,
-                        "std": 138,
+                        "mean": 208,
+                        "std": 155,
                         "min": 32,
                         "25%": 120,
                         "50%": 203,
-                        "75%": 280,
-                        "max": 351
+                        "75%": 291,
+                        "max": 395
                     }
                 },
                 "lengths": {
@@ -10733,13 +13425,7 @@
                     "overlap": 679
                 }
             ],
-            "eclipsed_reaches": [
-                "880740",
-                "880578",
-                "880796",
-                "879822",
-                "880584"
-            ]
+            "eclipsed_reaches": []
         },
         "880550": {
             "us_xs": {
@@ -10757,9 +13443,10 @@
                 "xs_id": 208.89
             },
             "eclipsed": false,
-            "low_flow": 245383,
-            "high_flow": 862606,
+            "low_flow": 184037,
+            "high_flow": 1035127,
             "network_to_id": "880814",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10800,9 +13487,6 @@
                 }
             ],
             "eclipsed_reaches": [
-                "880530",
-                "882724",
-                "880528",
                 "880814"
             ]
         },
@@ -10822,9 +13506,10 @@
                 "xs_id": 209.46
             },
             "eclipsed": false,
-            "low_flow": 245383,
-            "high_flow": 862597,
+            "low_flow": 184037,
+            "high_flow": 1035116,
             "network_to_id": "880550",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10864,12 +13549,7 @@
                     "overlap": 49
                 }
             ],
-            "eclipsed_reaches": [
-                "879772",
-                "880556",
-                "879774",
-                "879778"
-            ]
+            "eclipsed_reaches": []
         },
         "880678": {
             "us_xs": {
@@ -10887,9 +13567,10 @@
                 "xs_id": 194.97
             },
             "eclipsed": false,
-            "low_flow": 245427,
-            "high_flow": 852664,
+            "low_flow": 184070,
+            "high_flow": 1023196,
             "network_to_id": "3624763",
+            "ds_slope": 2.9999999242136255e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10929,15 +13610,7 @@
                     "overlap": 1903
                 }
             ],
-            "eclipsed_reaches": [
-                "6018266"
-            ]
-        },
-        "880814": {
-            "eclipsed": true,
-            "low_flow": 245383,
-            "high_flow": 862599,
-            "network_to_id": "880562"
+            "eclipsed_reaches": []
         },
         "880648": {
             "us_xs": {
@@ -10955,9 +13628,10 @@
                 "xs_id": 198.81
             },
             "eclipsed": false,
-            "low_flow": 245382,
-            "high_flow": 852311,
+            "low_flow": 184036,
+            "high_flow": 1022773,
             "network_to_id": "880652",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -10997,11 +13671,7 @@
                     "overlap": 1745
                 }
             ],
-            "eclipsed_reaches": [
-                "879898",
-                "880646",
-                "6010082"
-            ]
+            "eclipsed_reaches": []
         },
         "882710": {
             "us_xs": {
@@ -11019,9 +13689,10 @@
                 "xs_id": 197.31
             },
             "eclipsed": false,
-            "low_flow": 245436,
-            "high_flow": 852750,
+            "low_flow": 184077,
+            "high_flow": 1023300,
             "network_to_id": "880678",
+            "ds_slope": 4.999999873689376e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11061,10 +13732,7 @@
                     "overlap": 651
                 }
             ],
-            "eclipsed_reaches": [
-                "880744",
-                "879928"
-            ]
+            "eclipsed_reaches": []
         },
         "880636": {
             "us_xs": {
@@ -11082,9 +13750,10 @@
                 "xs_id": 200.31
             },
             "eclipsed": false,
-            "low_flow": 245383,
-            "high_flow": 852347,
+            "low_flow": 184037,
+            "high_flow": 1022817,
             "network_to_id": "880648",
+            "ds_slope": 0.0033499998971819878,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11124,10 +13793,7 @@
                     "overlap": 43
                 }
             ],
-            "eclipsed_reaches": [
-                "879892",
-                "880634"
-            ]
+            "eclipsed_reaches": []
         },
         "880562": {
             "us_xs": {
@@ -11145,9 +13811,10 @@
                 "xs_id": 206.6
             },
             "eclipsed": false,
-            "low_flow": 245381,
-            "high_flow": 862559,
+            "low_flow": 184036,
+            "high_flow": 1035071,
             "network_to_id": "880580",
+            "ds_slope": 0.00011999999696854502,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11162,11 +13829,11 @@
                     },
                     "thalweg_offset": {
                         "count": 5,
-                        "mean": 289,
-                        "std": 198,
+                        "mean": 298,
+                        "std": 202,
                         "min": 51,
                         "25%": 110,
-                        "50%": 351,
+                        "50%": 395,
                         "75%": 452,
                         "max": 482
                     }
@@ -11187,12 +13854,7 @@
                     "overlap": 902
                 }
             ],
-            "eclipsed_reaches": [
-                "880830",
-                "880812",
-                "880560",
-                "880764"
-            ]
+            "eclipsed_reaches": []
         },
         "880618": {
             "us_xs": {
@@ -11210,9 +13872,10 @@
                 "xs_id": 201.29
             },
             "eclipsed": false,
-            "low_flow": 245381,
-            "high_flow": 852311,
+            "low_flow": 184036,
+            "high_flow": 1022774,
             "network_to_id": "880622",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11252,17 +13915,7 @@
                     "overlap": 1995
                 }
             ],
-            "eclipsed_reaches": [
-                "880742",
-                "880616",
-                "6010090"
-            ]
-        },
-        "880608": {
-            "eclipsed": true,
-            "low_flow": 0,
-            "high_flow": 852363,
-            "network_to_id": "880618"
+            "eclipsed_reaches": []
         },
         "880606": {
             "us_xs": {
@@ -11280,9 +13933,10 @@
                 "xs_id": 202.68
             },
             "eclipsed": false,
-            "low_flow": 245383,
-            "high_flow": 852365,
+            "low_flow": 184037,
+            "high_flow": 1022838,
             "network_to_id": "880608",
+            "ds_slope": 3.9999998989515007e-05,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11342,9 +13996,10 @@
                 "xs_id": 194.63
             },
             "eclipsed": false,
-            "low_flow": 405915,
-            "high_flow": 1942292,
+            "low_flow": 304436,
+            "high_flow": 2330751,
             "network_to_id": "3624695",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11402,9 +14057,10 @@
                 "xs_id": 193.28
             },
             "eclipsed": false,
-            "low_flow": 406090,
-            "high_flow": 1942224,
+            "low_flow": 304567,
+            "high_flow": 2330669,
             "network_to_id": "3624705",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11444,9 +14100,7 @@
                     "overlap": 1418
                 }
             ],
-            "eclipsed_reaches": [
-                "3624699"
-            ]
+            "eclipsed_reaches": []
         },
         "3624695": {
             "us_xs": {
@@ -11464,9 +14118,10 @@
                 "xs_id": 194.16
             },
             "eclipsed": false,
-            "low_flow": 406090,
-            "high_flow": 1942380,
+            "low_flow": 304568,
+            "high_flow": 2330857,
             "network_to_id": "3624701",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -11510,3787 +14165,347 @@
         },
         "5092604": {
             "eclipsed": true,
-            "low_flow": 417521,
-            "high_flow": 1893095,
-            "network_to_id": "5092614"
-        },
-        "5092614": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 279.89,
-                "max_elevation": 397.65,
-                "xs_id": 47.34
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 274.89,
-                "max_elevation": 400.1,
-                "xs_id": 45.36
-            },
-            "eclipsed": false,
-            "low_flow": 417488,
-            "high_flow": 1893092,
-            "network_to_id": "5096814",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 162,
-                        "std": 76,
-                        "min": 50,
-                        "25%": 151,
-                        "50%": 192,
-                        "75%": 203,
-                        "max": 216
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 173,
-                        "std": 149,
-                        "min": 32,
-                        "25%": 57,
-                        "50%": 157,
-                        "75%": 273,
-                        "max": 344
-                    }
-                },
-                "lengths": {
-                    "ras": 9676,
-                    "network": 10867,
-                    "network_to_ras_ratio": 1.12
-                },
-                "coverage": {
-                    "start": 0.03,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5096814",
-                    "overlap": 761
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092254",
-                "5092612",
-                "5092610"
-            ]
-        },
-        "5092606": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 285.8,
-                "max_elevation": 385.91,
-                "xs_id": 48.58
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 279.89,
-                "max_elevation": 397.65,
-                "xs_id": 47.34
-            },
-            "eclipsed": false,
-            "low_flow": 417517,
-            "high_flow": 1893048,
-            "network_to_id": "5092604",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 209,
-                        "std": 172,
-                        "min": 50,
-                        "25%": 103,
-                        "50%": 171,
-                        "75%": 277,
-                        "max": 445
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 221,
-                        "std": 50,
-                        "min": 154,
-                        "25%": 199,
-                        "50%": 231,
-                        "75%": 253,
-                        "max": 267
-                    }
-                },
-                "lengths": {
-                    "ras": 7390,
-                    "network": 8138,
-                    "network_to_ras_ratio": 1.1
-                },
-                "coverage": {
-                    "start": 0.16,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092614",
-                    "overlap": 348
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092604",
-                "5092528",
-                "5092608"
-            ]
-        },
-        "5092594": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 287.95,
-                "max_elevation": 386.42,
-                "xs_id": 54.43
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 286.58,
-                "max_elevation": 371.94,
-                "xs_id": 52.15
-            },
-            "eclipsed": false,
-            "low_flow": 415952,
-            "high_flow": 1885044,
-            "network_to_id": "5092598",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 102,
-                        "std": 85,
-                        "min": 32,
-                        "25%": 62,
-                        "50%": 71,
-                        "75%": 102,
-                        "max": 268
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 176,
-                        "std": 123,
-                        "min": 6,
-                        "25%": 120,
-                        "50%": 176,
-                        "75%": 213,
-                        "max": 374
-                    }
-                },
-                "lengths": {
-                    "ras": 12410,
-                    "network": 12611,
-                    "network_to_ras_ratio": 1.02
-                },
-                "coverage": {
-                    "start": 0.01,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092598",
-                    "overlap": 2475
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092596"
-            ]
-        },
-        "5092598": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 286.58,
-                "max_elevation": 371.94,
-                "xs_id": 52.15
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 281.43,
-                "max_elevation": 374.53,
-                "xs_id": 49.85
-            },
-            "eclipsed": false,
-            "low_flow": 415927,
-            "high_flow": 1884942,
-            "network_to_id": "5092748",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 9,
-                        "mean": 117,
-                        "std": 40,
-                        "min": 21,
-                        "25%": 110,
-                        "50%": 135,
-                        "75%": 144,
-                        "max": 145
-                    },
-                    "thalweg_offset": {
-                        "count": 9,
-                        "mean": 220,
-                        "std": 68,
-                        "min": 105,
-                        "25%": 220,
-                        "50%": 234,
-                        "75%": 255,
-                        "max": 299
-                    }
-                },
-                "lengths": {
-                    "ras": 14305,
-                    "network": 13929,
-                    "network_to_ras_ratio": 0.97
-                },
-                "coverage": {
-                    "start": 0.17,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092748",
-                    "overlap": 1938
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092236",
-                "5092600"
-            ]
-        },
-        "5092590": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 289.32,
-                "max_elevation": 381.9,
-                "xs_id": 55.0
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 287.95,
-                "max_elevation": 386.42,
-                "xs_id": 54.43
-            },
-            "eclipsed": false,
-            "low_flow": 415953,
-            "high_flow": 1885091,
-            "network_to_id": "5092594",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 175,
-                        "std": 131,
-                        "min": 82,
-                        "25%": 128,
-                        "50%": 175,
-                        "75%": 221,
-                        "max": 268
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 513,
-                        "std": 196,
-                        "min": 374,
-                        "25%": 444,
-                        "50%": 513,
-                        "75%": 582,
-                        "max": 652
-                    }
-                },
-                "lengths": {
-                    "ras": 2809,
-                    "network": 2968,
-                    "network_to_ras_ratio": 1.06
-                },
-                "coverage": {
-                    "start": 0.25,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092594",
-                    "overlap": 65
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092592"
-            ]
-        },
-        "5092586": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 277.82,
-                "max_elevation": 379.98,
-                "xs_id": 60.52
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 289.32,
-                "max_elevation": 381.9,
-                "xs_id": 55.0
-            },
-            "eclipsed": false,
-            "low_flow": 415937,
-            "high_flow": 1885024,
-            "network_to_id": "5092590",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 12,
-                        "mean": 107,
-                        "std": 72,
-                        "min": 15,
-                        "25%": 54,
-                        "50%": 84,
-                        "75%": 171,
-                        "max": 225
-                    },
-                    "thalweg_offset": {
-                        "count": 12,
-                        "mean": 228,
-                        "std": 180,
-                        "min": 17,
-                        "25%": 109,
-                        "50%": 184,
-                        "75%": 272,
-                        "max": 652
-                    }
-                },
-                "lengths": {
-                    "ras": 28174,
-                    "network": 27440,
-                    "network_to_ras_ratio": 0.97
-                },
-                "coverage": {
-                    "start": 0.01,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092590",
-                    "overlap": 967
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092160",
-                "5092148",
-                "5092130",
-                "5092114",
-                "5092092",
-                "5092588",
-                "5092100",
-                "5092098",
-                "5092116",
-                "5092152",
-                "5092150",
-                "5092146",
-                "5092074",
-                "5092072"
-            ]
-        },
-        "5092582": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 296.85,
-                "max_elevation": 378.78,
-                "xs_id": 61.83
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 277.82,
-                "max_elevation": 379.98,
-                "xs_id": 60.52
-            },
-            "eclipsed": false,
-            "low_flow": 416059,
-            "high_flow": 1885913,
-            "network_to_id": "5092586",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 14,
-                        "std": 10,
-                        "min": 4,
-                        "25%": 10,
-                        "50%": 16,
-                        "75%": 20,
-                        "max": 23
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 214,
-                        "std": 63,
-                        "min": 177,
-                        "25%": 177,
-                        "50%": 178,
-                        "75%": 232,
-                        "max": 286
-                    }
-                },
-                "lengths": {
-                    "ras": 6204,
-                    "network": 6274,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.13,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092586",
-                    "overlap": 337
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092022",
-                "5092578",
-                "5092580"
-            ]
-        },
-        "5092552": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 289.11,
-                "max_elevation": 380.06,
-                "xs_id": 68.66
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 299.46,
-                "max_elevation": 381.52,
-                "xs_id": 68.09
-            },
-            "eclipsed": false,
-            "low_flow": 416085,
-            "high_flow": 1885928,
-            "network_to_id": "5092562",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 92,
-                        "std": 17,
-                        "min": 80,
-                        "25%": 86,
-                        "50%": 92,
-                        "75%": 98,
-                        "max": 104
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 191,
-                        "std": 64,
-                        "min": 146,
-                        "25%": 169,
-                        "50%": 191,
-                        "75%": 214,
-                        "max": 237
-                    }
-                },
-                "lengths": {
-                    "ras": 2969,
-                    "network": 2972,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.47,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092562",
-                    "overlap": 1449
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092474",
-                "5091702",
-                "5092550",
-                "5096806"
-            ]
-        },
-        "5092542": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 302.66,
-                "max_elevation": 386.33,
-                "xs_id": 69.75
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 289.11,
-                "max_elevation": 380.06,
-                "xs_id": 68.66
-            },
-            "eclipsed": false,
-            "low_flow": 416065,
-            "high_flow": 1885832,
-            "network_to_id": "5092552",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 78,
-                        "std": 43,
-                        "min": 34,
-                        "25%": 57,
-                        "50%": 80,
-                        "75%": 100,
-                        "max": 120
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 189,
-                        "std": 111,
-                        "min": 62,
-                        "25%": 150,
-                        "50%": 237,
-                        "75%": 253,
-                        "max": 268
-                    }
-                },
-                "lengths": {
-                    "ras": 5773,
-                    "network": 5815,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.37,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092552",
-                    "overlap": 1346
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092546",
-                "5092544",
-                "5089718"
-            ]
-        },
-        "5090014": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 286.95,
-                "max_elevation": 387.38,
-                "xs_id": 70.27
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 302.66,
-                "max_elevation": 386.33,
-                "xs_id": 69.75
-            },
-            "eclipsed": false,
-            "low_flow": 416073,
-            "high_flow": 1885951,
-            "network_to_id": "5092542",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 98,
-                        "std": 32,
-                        "min": 76,
-                        "25%": 87,
-                        "50%": 98,
-                        "75%": 109,
-                        "max": 120
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 147,
-                        "std": 121,
-                        "min": 62,
-                        "25%": 105,
-                        "50%": 147,
-                        "75%": 190,
-                        "max": 233
-                    }
-                },
-                "lengths": {
-                    "ras": 2748,
-                    "network": 2899,
-                    "network_to_ras_ratio": 1.06
-                },
-                "coverage": {
-                    "start": 0.77,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092542",
-                    "overlap": 2664
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "5090010": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 297.2,
-                "max_elevation": 395.98,
-                "xs_id": 71.78
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 286.95,
-                "max_elevation": 387.38,
-                "xs_id": 70.27
-            },
-            "eclipsed": false,
-            "low_flow": 416072,
-            "high_flow": 1885914,
-            "network_to_id": "5090014",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 55,
-                        "std": 18,
-                        "min": 32,
-                        "25%": 49,
-                        "50%": 55,
-                        "75%": 61,
-                        "max": 76
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 137,
-                        "std": 100,
-                        "min": 7,
-                        "25%": 87,
-                        "50%": 154,
-                        "75%": 203,
-                        "max": 233
-                    }
-                },
-                "lengths": {
-                    "ras": 8067,
-                    "network": 8175,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5090014",
-                    "overlap": 796
-                }
-            ],
-            "eclipsed_reaches": [
-                "5090012"
-            ]
-        },
-        "5090004": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 305.12,
-                "max_elevation": 388.18,
-                "xs_id": 72.31
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 297.2,
-                "max_elevation": 395.98,
-                "xs_id": 71.78
-            },
-            "eclipsed": false,
-            "low_flow": 416082,
-            "high_flow": 1885943,
-            "network_to_id": "5090010",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 45,
-                        "std": 15,
-                        "min": 35,
-                        "25%": 40,
-                        "50%": 45,
-                        "75%": 50,
-                        "max": 56
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 115,
-                        "std": 112,
-                        "min": 36,
-                        "25%": 75,
-                        "50%": 115,
-                        "75%": 154,
-                        "max": 193
-                    }
-                },
-                "lengths": {
-                    "ras": 2843,
-                    "network": 2866,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.53,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5090010",
-                    "overlap": 648
-                }
-            ],
-            "eclipsed_reaches": [
-                "5090006",
-                "5089602"
-            ]
-        },
-        "5090000": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 302.05,
-                "max_elevation": 392.26,
-                "xs_id": 73.56
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 305.12,
-                "max_elevation": 388.18,
-                "xs_id": 72.31
-            },
-            "eclipsed": false,
-            "low_flow": 416084,
-            "high_flow": 1885976,
-            "network_to_id": "5090004",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 37,
-                        "std": 2,
-                        "min": 35,
-                        "25%": 36,
-                        "50%": 38,
-                        "75%": 39,
-                        "max": 39
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 154,
-                        "std": 103,
-                        "min": 36,
-                        "25%": 120,
-                        "50%": 205,
-                        "75%": 214,
-                        "max": 222
-                    }
-                },
-                "lengths": {
-                    "ras": 6379,
-                    "network": 6447,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.07,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5090004",
-                    "overlap": 2525
-                }
-            ],
-            "eclipsed_reaches": [
-                "5090002"
-            ]
-        },
-        "5089998": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 303.92,
-                "max_elevation": 389.02,
-                "xs_id": 74.89
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 302.05,
-                "max_elevation": 392.26,
-                "xs_id": 73.56
-            },
-            "eclipsed": false,
-            "low_flow": 416084,
-            "high_flow": 1885953,
-            "network_to_id": "5090000",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 27,
-                        "std": 11,
-                        "min": 20,
-                        "25%": 21,
-                        "50%": 22,
-                        "75%": 31,
-                        "max": 39
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 133,
-                        "std": 110,
-                        "min": 10,
-                        "25%": 89,
-                        "50%": 168,
-                        "75%": 195,
-                        "max": 222
-                    }
-                },
-                "lengths": {
-                    "ras": 7210,
-                    "network": 7215,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5090000",
-                    "overlap": 314
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089526",
-                "5089994",
-                "5089996"
-            ]
-        },
-        "5089990": {
-            "eclipsed": true,
-            "low_flow": 416053,
-            "high_flow": 1885248,
-            "network_to_id": "5089998"
-        },
-        "5089984": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 297.11,
-                "max_elevation": 380.04,
-                "xs_id": 77.21
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 298.22,
-                "max_elevation": 389.7,
-                "xs_id": 76.2
-            },
-            "eclipsed": false,
-            "low_flow": 415015,
-            "high_flow": 1897025,
-            "network_to_id": "5089986",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 78,
-                        "std": 63,
-                        "min": 10,
-                        "25%": 49,
-                        "50%": 87,
-                        "75%": 112,
-                        "max": 136
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 191,
-                        "std": 50,
-                        "min": 133,
-                        "25%": 176,
-                        "50%": 219,
-                        "75%": 220,
-                        "max": 222
-                    }
-                },
-                "lengths": {
-                    "ras": 5018,
-                    "network": 5010,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.47,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089986",
-                    "overlap": 1086
-                }
-            ],
-            "eclipsed_reaches": [
-                "5090036",
-                "5089412",
-                "5089982"
-            ]
-        },
-        "5089978": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 300.31,
-                "max_elevation": 390.84,
-                "xs_id": 81.09
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 297.11,
-                "max_elevation": 380.04,
-                "xs_id": 77.21
-            },
-            "eclipsed": false,
-            "low_flow": 415023,
-            "high_flow": 1897010,
-            "network_to_id": "5089984",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 10,
-                        "mean": 228,
-                        "std": 182,
-                        "min": 8,
-                        "25%": 110,
-                        "50%": 176,
-                        "75%": 258,
-                        "max": 557
-                    },
-                    "thalweg_offset": {
-                        "count": 10,
-                        "mean": 309,
-                        "std": 302,
-                        "min": 49,
-                        "25%": 84,
-                        "50%": 224,
-                        "75%": 433,
-                        "max": 1036
-                    }
-                },
-                "lengths": {
-                    "ras": 20960,
-                    "network": 21216,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089984",
-                    "overlap": 3500
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089980",
-                "13786976",
-                "13786380",
-                "13786364",
-                "13786672",
-                "13786978",
-                "13786368",
-                "13786968"
-            ]
-        },
-        "5092698": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 269.488,
-                "max_elevation": 341.5351,
-                "xs_id": 30.82
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 275.459,
-                "max_elevation": 342.95,
-                "xs_id": 28.57
-            },
-            "eclipsed": false,
-            "low_flow": 417506,
-            "high_flow": 1893973,
-            "network_to_id": "5092712",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 5,
-                        "mean": 46,
-                        "std": 26,
-                        "min": 3,
-                        "25%": 46,
-                        "50%": 50,
-                        "75%": 60,
-                        "max": 71
-                    },
-                    "thalweg_offset": {
-                        "count": 5,
-                        "mean": 147,
-                        "std": 119,
-                        "min": 16,
-                        "25%": 74,
-                        "50%": 126,
-                        "75%": 191,
-                        "max": 326
-                    }
-                },
-                "lengths": {
-                    "ras": 12389,
-                    "network": 12442,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.03,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092712",
-                    "overlap": 1660
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "5092676": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 278.543,
-                "max_elevation": 344.488,
-                "xs_id": 34.69
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 269.488,
-                "max_elevation": 341.5351,
-                "xs_id": 30.82
-            },
-            "eclipsed": false,
-            "low_flow": 417509,
-            "high_flow": 1893931,
-            "network_to_id": "5092698",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 10,
-                        "mean": 26,
-                        "std": 19,
-                        "min": 2,
-                        "25%": 14,
-                        "50%": 25,
-                        "75%": 32,
-                        "max": 60
-                    },
-                    "thalweg_offset": {
-                        "count": 10,
-                        "mean": 163,
-                        "std": 104,
-                        "min": 10,
-                        "25%": 70,
-                        "50%": 173,
-                        "75%": 234,
-                        "max": 326
-                    }
-                },
-                "lengths": {
-                    "ras": 20591,
-                    "network": 20578,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092698",
-                    "overlap": 327
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092372",
-                "5092678"
-            ]
-        },
-        "5092652": {
-            "eclipsed": true,
-            "low_flow": 417668,
-            "high_flow": 1894321,
-            "network_to_id": "5092676"
-        },
-        "5092634": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 285.86,
-                "max_elevation": 361.22,
-                "xs_id": 39.02
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 287.73,
-                "max_elevation": 354.3309,
-                "xs_id": 38.58
-            },
-            "eclipsed": false,
-            "low_flow": 417756,
-            "high_flow": 1894581,
-            "network_to_id": "5092646",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 49,
-                        "std": 17,
-                        "min": 37,
-                        "25%": 43,
-                        "50%": 49,
-                        "75%": 55,
-                        "max": 61
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 114,
-                        "std": 136,
-                        "min": 18,
-                        "25%": 66,
-                        "50%": 114,
-                        "75%": 162,
-                        "max": 210
-                    }
-                },
-                "lengths": {
-                    "ras": 2393,
-                    "network": 2466,
-                    "network_to_ras_ratio": 1.03
-                },
-                "coverage": {
-                    "start": 0.49,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092646",
-                    "overlap": 53
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092636"
-            ]
-        },
-        "5092626": {
-            "eclipsed": true,
-            "low_flow": 417796,
-            "high_flow": 1894604,
-            "network_to_id": "5092630"
-        },
-        "5092630": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 284.71,
-                "max_elevation": 367.99,
-                "xs_id": 41.1
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 285.86,
-                "max_elevation": 361.22,
-                "xs_id": 39.02
-            },
-            "eclipsed": false,
-            "low_flow": 417758,
-            "high_flow": 1894601,
-            "network_to_id": "5092634",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 5,
-                        "mean": 65,
-                        "std": 32,
-                        "min": 27,
-                        "25%": 37,
-                        "50%": 72,
-                        "75%": 94,
-                        "max": 96
-                    },
-                    "thalweg_offset": {
-                        "count": 5,
-                        "mean": 141,
-                        "std": 98,
-                        "min": 18,
-                        "25%": 116,
-                        "50%": 117,
-                        "75%": 165,
-                        "max": 288
-                    }
-                },
-                "lengths": {
-                    "ras": 10891,
-                    "network": 10760,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.21,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092634",
-                    "overlap": 2320
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092632"
-            ]
-        },
-        "5092602": {
-            "eclipsed": true,
-            "low_flow": 415966,
-            "high_flow": 1885418,
-            "network_to_id": "5092606"
-        },
-        "5089946": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 306.03,
-                "max_elevation": 401.3,
-                "xs_id": 87.94
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 290.92,
-                "max_elevation": 389.66,
-                "xs_id": 84.96
-            },
-            "eclipsed": false,
-            "low_flow": 415064,
-            "high_flow": 1897775,
-            "network_to_id": "5096766",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 7,
-                        "mean": 30,
-                        "std": 23,
-                        "min": 4,
-                        "25%": 10,
-                        "50%": 30,
-                        "75%": 45,
-                        "max": 66
-                    },
-                    "thalweg_offset": {
-                        "count": 7,
-                        "mean": 209,
-                        "std": 112,
-                        "min": 39,
-                        "25%": 139,
-                        "50%": 243,
-                        "75%": 269,
-                        "max": 363
-                    }
-                },
-                "lengths": {
-                    "ras": 15159,
-                    "network": 15243,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.06,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5096766",
-                    "overlap": 938
-                }
-            ],
-            "eclipsed_reaches": [
-                "5088922",
-                "5088934",
-                "5089944",
-                "13786622",
-                "5089816",
-                "5088802",
-                "13785886",
-                "13785900"
-            ]
-        },
-        "5096766": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 290.92,
-                "max_elevation": 389.66,
-                "xs_id": 84.96
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 292.77,
-                "max_elevation": 400.4,
-                "xs_id": 83.97
-            },
-            "eclipsed": false,
-            "low_flow": 415077,
-            "high_flow": 1897755,
-            "network_to_id": "5089952",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 83,
-                        "std": 111,
-                        "min": 10,
-                        "25%": 20,
-                        "50%": 30,
-                        "75%": 120,
-                        "max": 210
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 355,
-                        "std": 126,
-                        "min": 265,
-                        "25%": 284,
-                        "50%": 302,
-                        "75%": 400,
-                        "max": 499
-                    }
-                },
-                "lengths": {
-                    "ras": 5128,
-                    "network": 4846,
-                    "network_to_ras_ratio": 0.94
-                },
-                "coverage": {
-                    "start": 0.27,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089952",
-                    "overlap": 2369
-                }
-            ],
-            "eclipsed_reaches": [
-                "13786030",
-                "13786800",
-                "13785944",
-                "13785948",
-                "13785966",
-                "13785964",
-                "13785946"
-            ]
-        },
-        "5089952": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 292.77,
-                "max_elevation": 400.4,
-                "xs_id": 83.97
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 295.95,
-                "max_elevation": 400.43,
-                "xs_id": 82.48
-            },
-            "eclipsed": false,
-            "low_flow": 415066,
-            "high_flow": 1897693,
-            "network_to_id": "5089960",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 111,
-                        "std": 73,
-                        "min": 35,
-                        "25%": 82,
-                        "50%": 100,
-                        "75%": 129,
-                        "max": 210
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 161,
-                        "std": 96,
-                        "min": 89,
-                        "25%": 107,
-                        "50%": 126,
-                        "75%": 181,
-                        "max": 302
-                    }
-                },
-                "lengths": {
-                    "ras": 8045,
-                    "network": 7935,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.28,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089970",
-                    "overlap": 354
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089074",
-                "5089958",
-                "5089956",
-                "5089954",
-                "5089960",
-                "5090064",
-                "13786888",
-                "13786882",
-                "13786874",
-                "13786884",
-                "13786886",
-                "13786860",
-                "13786104",
-                "13786892",
-                "13786666",
-                "13786880",
-                "13786890"
-            ]
-        },
-        "5092562": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 299.46,
-                "max_elevation": 381.52,
-                "xs_id": 68.09
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 298.71,
-                "max_elevation": 380.4,
-                "xs_id": 66.98
-            },
-            "eclipsed": false,
-            "low_flow": 416079,
-            "high_flow": 1886048,
-            "network_to_id": "5092566",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 42,
-                        "std": 55,
-                        "min": 3,
-                        "25%": 11,
-                        "50%": 19,
-                        "75%": 62,
-                        "max": 104
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 158,
-                        "std": 59,
-                        "min": 106,
-                        "25%": 126,
-                        "50%": 146,
-                        "75%": 184,
-                        "max": 222
-                    }
-                },
-                "lengths": {
-                    "ras": 5950,
-                    "network": 5971,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.23,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092566",
-                    "overlap": 1210
-                }
-            ],
-            "eclipsed_reaches": [
-                "5091732",
-                "5091768",
-                "5092556",
-                "5092560"
-            ]
-        },
-        "5096814": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 274.89,
-                "max_elevation": 400.1,
-                "xs_id": 45.36
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 277.43,
-                "max_elevation": 400.0,
-                "xs_id": 44.29
-            },
-            "eclipsed": false,
-            "low_flow": 417816,
-            "high_flow": 1894550,
-            "network_to_id": "5092616",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 130,
-                        "std": 60,
-                        "min": 66,
-                        "25%": 103,
-                        "50%": 140,
-                        "75%": 162,
-                        "max": 185
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 112,
-                        "std": 133,
-                        "min": 32,
-                        "25%": 35,
-                        "50%": 39,
-                        "75%": 152,
-                        "max": 265
-                    }
-                },
-                "lengths": {
-                    "ras": 5807,
-                    "network": 5609,
-                    "network_to_ras_ratio": 0.97
-                },
-                "coverage": {
-                    "start": 0.13,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092616",
-                    "overlap": 635
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092752"
-            ]
-        },
-        "5092748": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 281.43,
-                "max_elevation": 374.53,
-                "xs_id": 49.85
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 285.8,
-                "max_elevation": 385.91,
-                "xs_id": 48.58
-            },
-            "eclipsed": false,
-            "low_flow": 415946,
-            "high_flow": 1885169,
-            "network_to_id": "5092602",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 309,
-                        "std": 173,
-                        "min": 115,
-                        "25%": 241,
-                        "50%": 367,
-                        "75%": 406,
-                        "max": 445
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 237,
-                        "std": 75,
-                        "min": 154,
-                        "25%": 206,
-                        "50%": 258,
-                        "75%": 278,
-                        "max": 299
-                    }
-                },
-                "lengths": {
-                    "ras": 7080,
-                    "network": 7892,
-                    "network_to_ras_ratio": 1.11
-                },
-                "coverage": {
-                    "start": 0.25,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092606",
-                    "overlap": 1185
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092244",
-                "5092242",
-                "5092746",
-                "5092750",
-                "5092602",
-                "5027669",
-                "5027717"
-            ]
-        },
-        "5092566": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 298.71,
-                "max_elevation": 380.4,
-                "xs_id": 66.98
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 298.52,
-                "max_elevation": 380.14,
-                "xs_id": 66.3
-            },
-            "eclipsed": false,
-            "low_flow": 416079,
-            "high_flow": 1886047,
-            "network_to_id": "5092568",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 12,
-                        "std": 13,
-                        "min": 3,
-                        "25%": 7,
-                        "50%": 12,
-                        "75%": 17,
-                        "max": 21
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 75,
-                        "std": 43,
-                        "min": 45,
-                        "25%": 60,
-                        "50%": 75,
-                        "75%": 91,
-                        "max": 106
-                    }
-                },
-                "lengths": {
-                    "ras": 3028,
-                    "network": 3038,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.4,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092568",
-                    "overlap": 1213
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092564"
-            ]
-        },
-        "5092568": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 298.52,
-                "max_elevation": 380.14,
-                "xs_id": 66.3
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 297.35,
-                "max_elevation": 385.17,
-                "xs_id": 65.84
-            },
-            "eclipsed": false,
-            "low_flow": 416078,
-            "high_flow": 1886003,
-            "network_to_id": "5092572",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 42,
-                        "std": 29,
-                        "min": 21,
-                        "25%": 32,
-                        "50%": 42,
-                        "75%": 52,
-                        "max": 63
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 216,
-                        "std": 241,
-                        "min": 45,
-                        "25%": 130,
-                        "50%": 216,
-                        "75%": 301,
-                        "max": 386
-                    }
-                },
-                "lengths": {
-                    "ras": 3120,
-                    "network": 3052,
-                    "network_to_ras_ratio": 0.98
-                },
-                "coverage": {
-                    "start": 0.46,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092572",
-                    "overlap": 1652
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092570"
-            ]
-        },
-        "5092572": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 297.35,
-                "max_elevation": 385.17,
-                "xs_id": 65.84
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 296.85,
-                "max_elevation": 378.78,
-                "xs_id": 61.83
-            },
-            "eclipsed": false,
-            "low_flow": 416064,
-            "high_flow": 1885986,
-            "network_to_id": "5092582",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 8,
-                        "mean": 93,
-                        "std": 80,
-                        "min": 4,
-                        "25%": 45,
-                        "50%": 63,
-                        "75%": 123,
-                        "max": 244
-                    },
-                    "thalweg_offset": {
-                        "count": 8,
-                        "mean": 239,
-                        "std": 80,
-                        "min": 125,
-                        "25%": 187,
-                        "50%": 233,
-                        "75%": 277,
-                        "max": 386
-                    }
-                },
-                "lengths": {
-                    "ras": 21093,
-                    "network": 21102,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092582",
-                    "overlap": 904
-                }
-            ],
-            "eclipsed_reaches": [
-                "5091838",
-                "5092574",
-                "5091798",
-                "5091816",
-                "5091844",
-                "5091722",
-                "937140085",
-                "5091974"
-            ]
-        },
-        "5089986": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 298.22,
-                "max_elevation": 389.7,
-                "xs_id": 76.2
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 303.92,
-                "max_elevation": 389.02,
-                "xs_id": 74.89
-            },
-            "eclipsed": false,
-            "low_flow": 415018,
-            "high_flow": 1897026,
-            "network_to_id": "5089990",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 64,
-                        "std": 36,
-                        "min": 22,
-                        "25%": 52,
-                        "50%": 82,
-                        "75%": 85,
-                        "max": 87
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 200,
-                        "std": 180,
-                        "min": 10,
-                        "25%": 116,
-                        "50%": 222,
-                        "75%": 295,
-                        "max": 369
-                    }
-                },
-                "lengths": {
-                    "ras": 6485,
-                    "network": 6537,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.26,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089998",
-                    "overlap": 634
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089990",
-                "13786982",
-                "13786980"
-            ]
-        },
-        "5089970": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 295.95,
-                "max_elevation": 400.43,
-                "xs_id": 82.48
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 300.31,
-                "max_elevation": 390.84,
-                "xs_id": 81.09
-            },
-            "eclipsed": false,
-            "low_flow": 415061,
-            "high_flow": 1897602,
-            "network_to_id": "5089978",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 62,
-                        "std": 48,
-                        "min": 7,
-                        "25%": 29,
-                        "50%": 67,
-                        "75%": 100,
-                        "max": 107
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 177,
-                        "std": 104,
-                        "min": 89,
-                        "25%": 108,
-                        "50%": 148,
-                        "75%": 217,
-                        "max": 322
-                    }
-                },
-                "lengths": {
-                    "ras": 7420,
-                    "network": 7518,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.06,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089978",
-                    "overlap": 1449
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089154",
-                "5089972"
-            ]
+            "low_flow": 313141,
+            "high_flow": 2271715,
+            "network_to_id": "5092614",
+            "ds_slope": 9.999999747378752e-06
         },
         "5089960": {
             "eclipsed": true,
-            "low_flow": 415069,
-            "high_flow": 1897713,
-            "network_to_id": "5089970"
+            "low_flow": 311301,
+            "high_flow": 2277256,
+            "network_to_id": "5089970",
+            "ds_slope": 0.0009800000116229057
         },
-        "5089926": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 306.01,
-                "max_elevation": 399.91,
-                "xs_id": 91.32
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 307.68,
-                "max_elevation": 403.64,
-                "xs_id": 89.55
-            },
-            "eclipsed": false,
-            "low_flow": 415067,
-            "high_flow": 1897887,
-            "network_to_id": "5089932",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 41,
-                        "std": 33,
-                        "min": 8,
-                        "25%": 17,
-                        "50%": 40,
-                        "75%": 64,
-                        "max": 77
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 184,
-                        "std": 174,
-                        "min": 4,
-                        "25%": 56,
-                        "50%": 180,
-                        "75%": 308,
-                        "max": 374
-                    }
-                },
-                "lengths": {
-                    "ras": 8403,
-                    "network": 8420,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.05,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089938",
-                    "overlap": 131
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089934",
-                "5089928",
-                "5089930",
-                "5089932"
-            ]
+        "5092602": {
+            "eclipsed": true,
+            "low_flow": 311974,
+            "high_flow": 2262502,
+            "network_to_id": "5092606",
+            "ds_slope": 0.0003699999942909926
+        },
+        "5089990": {
+            "eclipsed": true,
+            "low_flow": 312040,
+            "high_flow": 2262298,
+            "network_to_id": "5089998",
+            "ds_slope": 9.999999747378752e-06
         },
         "5089932": {
             "eclipsed": true,
-            "low_flow": 415069,
-            "high_flow": 1897867,
-            "network_to_id": "5089938"
+            "low_flow": 311302,
+            "high_flow": 2277441,
+            "network_to_id": "5089938",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5089938": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 307.68,
-                "max_elevation": 403.64,
-                "xs_id": 89.55
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 306.03,
-                "max_elevation": 401.3,
-                "xs_id": 87.94
-            },
-            "eclipsed": false,
-            "low_flow": 415061,
-            "high_flow": 1897750,
-            "network_to_id": "5089946",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 80,
-                        "std": 52,
-                        "min": 20,
-                        "25%": 54,
-                        "50%": 77,
-                        "75%": 102,
-                        "max": 145
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 121,
-                        "std": 97,
-                        "min": 4,
-                        "25%": 62,
-                        "50%": 132,
-                        "75%": 191,
-                        "max": 217
-                    }
-                },
-                "lengths": {
-                    "ras": 8457,
-                    "network": 8553,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.02,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089946",
-                    "overlap": 941
-                }
-            ],
-            "eclipsed_reaches": [
-                "5088902",
-                "5089936",
-                "5088756"
-            ]
+        "5092652": {
+            "eclipsed": true,
+            "low_flow": 313251,
+            "high_flow": 2273185,
+            "network_to_id": "5092676",
+            "ds_slope": 0.00026000000070780516
         },
-        "5092646": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 287.73,
-                "max_elevation": 354.3309,
-                "xs_id": 38.58
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 278.543,
-                "max_elevation": 344.488,
-                "xs_id": 34.69
-            },
-            "eclipsed": false,
-            "low_flow": 417668,
-            "high_flow": 1894346,
-            "network_to_id": "5092652",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 9,
-                        "mean": 33,
-                        "std": 32,
-                        "min": 2,
-                        "25%": 4,
-                        "50%": 27,
-                        "75%": 41,
-                        "max": 100
-                    },
-                    "thalweg_offset": {
-                        "count": 9,
-                        "mean": 242,
-                        "std": 159,
-                        "min": 56,
-                        "25%": 88,
-                        "50%": 210,
-                        "75%": 350,
-                        "max": 458
-                    }
-                },
-                "lengths": {
-                    "ras": 20823,
-                    "network": 20962,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.0,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092676",
-                    "overlap": 1742
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092652",
-                "5092740",
-                "5092332",
-                "5092340",
-                "5092338",
-                "5092644",
-                "5092650",
-                "5092342",
-                "5092638",
-                "5092334",
-                "5092640",
-                "5092648",
-                "5092642"
-            ]
-        },
-        "5092622": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 273.06,
-                "max_elevation": 360.15,
-                "xs_id": 43.2
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 284.71,
-                "max_elevation": 367.99,
-                "xs_id": 41.1
-            },
-            "eclipsed": false,
-            "low_flow": 417793,
-            "high_flow": 1894602,
-            "network_to_id": "5092626",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 5,
-                        "mean": 105,
-                        "std": 56,
-                        "min": 57,
-                        "25%": 70,
-                        "50%": 72,
-                        "75%": 144,
-                        "max": 184
-                    },
-                    "thalweg_offset": {
-                        "count": 5,
-                        "mean": 152,
-                        "std": 88,
-                        "min": 75,
-                        "25%": 88,
-                        "50%": 116,
-                        "75%": 197,
-                        "max": 285
-                    }
-                },
-                "lengths": {
-                    "ras": 11279,
-                    "network": 11468,
-                    "network_to_ras_ratio": 1.02
-                },
-                "coverage": {
-                    "start": 0.12,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092630",
-                    "overlap": 2266
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092628",
-                "5092624",
-                "5092620",
-                "5092626"
-            ]
-        },
-        "5092616": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 277.43,
-                "max_elevation": 400.0,
-                "xs_id": 44.29
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 273.06,
-                "max_elevation": 360.15,
-                "xs_id": 43.2
-            },
-            "eclipsed": false,
-            "low_flow": 417817,
-            "high_flow": 1894585,
-            "network_to_id": "5092622",
-            "gage": "07022000",
-            "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07022000&legacy=1",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 158,
-                        "std": 16,
-                        "min": 140,
-                        "25%": 149,
-                        "50%": 157,
-                        "75%": 164,
-                        "max": 184
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 91,
-                        "std": 90,
-                        "min": 19,
-                        "25%": 37,
-                        "50%": 73,
-                        "75%": 87,
-                        "max": 265
-                    }
-                },
-                "lengths": {
-                    "ras": 5448,
-                    "network": 5765,
-                    "network_to_ras_ratio": 1.06
-                },
-                "coverage": {
-                    "start": 0.12,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092622",
-                    "overlap": 1103
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092618"
-            ]
-        },
-        "5092658": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 266.437,
-                "max_elevation": 328.15,
-                "xs_id": 15.43
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 252.133,
-                "max_elevation": 340.2229,
-                "xs_id": 12.67
-            },
-            "eclipsed": false,
-            "low_flow": 417345,
-            "high_flow": 1893676,
-            "network_to_id": "5092656",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 7,
-                        "mean": 64,
-                        "std": 36,
-                        "min": 6,
-                        "25%": 44,
-                        "50%": 71,
-                        "75%": 84,
-                        "max": 114
-                    },
-                    "thalweg_offset": {
-                        "count": 7,
-                        "mean": 337,
-                        "std": 233,
-                        "min": 108,
-                        "25%": 157,
-                        "50%": 202,
-                        "75%": 541,
-                        "max": 655
-                    }
-                },
-                "lengths": {
-                    "ras": 12587,
-                    "network": 13001,
-                    "network_to_ras_ratio": 1.03
-                },
-                "coverage": {
-                    "start": 0.07,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092656",
-                    "overlap": 2302
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092742",
-                "5092654",
-                "5092354"
-            ]
-        },
-        "5093444": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 278.084,
-                "max_elevation": 340.2229,
-                "xs_id": 24.49
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 272.507,
-                "max_elevation": 339.567,
-                "xs_id": 22.03
-            },
-            "eclipsed": false,
-            "low_flow": 417416,
-            "high_flow": 1893742,
-            "network_to_id": "5092710",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 26,
-                        "std": 26,
-                        "min": 3,
-                        "25%": 8,
-                        "50%": 21,
-                        "75%": 30,
-                        "max": 74
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 153,
-                        "std": 67,
-                        "min": 89,
-                        "25%": 111,
-                        "50%": 150,
-                        "75%": 155,
-                        "max": 276
-                    }
-                },
-                "lengths": {
-                    "ras": 15881,
-                    "network": 15624,
-                    "network_to_ras_ratio": 0.98
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092704",
-                    "overlap": 386
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092710",
-                "5092424",
-                "5092708",
-                "653824"
-            ]
-        },
-        "5092712": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 275.459,
-                "max_elevation": 342.95,
-                "xs_id": 28.57
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 278.084,
-                "max_elevation": 340.2229,
-                "xs_id": 24.49
-            },
-            "eclipsed": false,
-            "low_flow": 417479,
-            "high_flow": 1893923,
-            "network_to_id": "5093444",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 8,
-                        "mean": 33,
-                        "std": 37,
-                        "min": 3,
-                        "25%": 4,
-                        "50%": 15,
-                        "75%": 59,
-                        "max": 95
-                    },
-                    "thalweg_offset": {
-                        "count": 8,
-                        "mean": 235,
-                        "std": 122,
-                        "min": 89,
-                        "25%": 189,
-                        "50%": 216,
-                        "75%": 234,
-                        "max": 513
-                    }
-                },
-                "lengths": {
-                    "ras": 21765,
-                    "network": 21946,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.07,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5093444",
-                    "overlap": 1188
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "5092704": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 272.507,
-                "max_elevation": 339.567,
-                "xs_id": 22.03
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 264.698,
-                "max_elevation": 340.2102,
-                "xs_id": 18.05
-            },
-            "eclipsed": false,
-            "low_flow": 417393,
-            "high_flow": 1893700,
-            "network_to_id": "5092684",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 10,
-                        "mean": 15,
-                        "std": 8,
-                        "min": 4,
-                        "25%": 10,
-                        "50%": 13,
-                        "75%": 19,
-                        "max": 32
-                    },
-                    "thalweg_offset": {
-                        "count": 10,
-                        "mean": 208,
-                        "std": 115,
-                        "min": 59,
-                        "25%": 150,
-                        "50%": 173,
-                        "75%": 212,
-                        "max": 433
-                    }
-                },
-                "lengths": {
-                    "ras": 20504,
-                    "network": 20561,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.02,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092684",
-                    "overlap": 1429
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092382",
-                "5092402",
-                "5092690",
-                "5092688"
-            ]
-        },
-        "5092664": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 264.075,
-                "max_elevation": 323.819,
-                "xs_id": 16.95
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 266.437,
-                "max_elevation": 328.15,
-                "xs_id": 15.43
-            },
-            "eclipsed": false,
-            "low_flow": 417384,
-            "high_flow": 1893818,
-            "network_to_id": "5092658",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 29,
-                        "std": 14,
-                        "min": 9,
-                        "25%": 26,
-                        "50%": 34,
-                        "75%": 38,
-                        "max": 40
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 170,
-                        "std": 224,
-                        "min": 6,
-                        "25%": 60,
-                        "50%": 86,
-                        "75%": 196,
-                        "max": 501
-                    }
-                },
-                "lengths": {
-                    "ras": 7956,
-                    "network": 8175,
-                    "network_to_ras_ratio": 1.03
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092658",
-                    "overlap": 850
-                }
-            ],
-            "eclipsed_reaches": []
-        },
-        "5092670": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 230.282,
-                "max_elevation": 323.491,
-                "xs_id": 17.25
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 264.075,
-                "max_elevation": 323.819,
-                "xs_id": 16.95
-            },
-            "eclipsed": false,
-            "low_flow": 417386,
-            "high_flow": 1893798,
-            "network_to_id": "5092664",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 33,
-                        "std": 10,
-                        "min": 26,
-                        "25%": 30,
-                        "50%": 33,
-                        "75%": 37,
-                        "max": 40
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 212,
-                        "std": 290,
-                        "min": 6,
-                        "25%": 109,
-                        "50%": 212,
-                        "75%": 314,
-                        "max": 417
-                    }
-                },
-                "lengths": {
-                    "ras": 1597,
-                    "network": 1666,
-                    "network_to_ras_ratio": 1.04
-                },
-                "coverage": {
-                    "start": 0.29,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092664",
-                    "overlap": 611
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092666"
-            ]
-        },
-        "5092684": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 264.698,
-                "max_elevation": 340.2102,
-                "xs_id": 18.05
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 230.282,
-                "max_elevation": 323.491,
-                "xs_id": 17.25
-            },
-            "eclipsed": false,
-            "low_flow": 417387,
-            "high_flow": 1893770,
-            "network_to_id": "5092670",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 25,
-                        "std": 14,
-                        "min": 4,
-                        "25%": 21,
-                        "50%": 29,
-                        "75%": 33,
-                        "max": 37
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 366,
-                        "std": 42,
-                        "min": 326,
-                        "25%": 334,
-                        "50%": 361,
-                        "75%": 393,
-                        "max": 417
-                    }
-                },
-                "lengths": {
-                    "ras": 4478,
-                    "network": 4477,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.26,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092670",
-                    "overlap": 440
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092386",
-                "5092680",
-                "5092682"
-            ]
+        "5092626": {
+            "eclipsed": true,
+            "low_flow": 313347,
+            "high_flow": 2273525,
+            "network_to_id": "5092630",
+            "ds_slope": 9.999999747378752e-06
         },
         "5092710": {
             "eclipsed": true,
-            "low_flow": 417414,
-            "high_flow": 1893797,
-            "network_to_id": "5092704"
+            "low_flow": 313061,
+            "high_flow": 2272557,
+            "network_to_id": "5092704",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5089922": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 308.77,
-                "max_elevation": 399.97,
-                "xs_id": 91.83
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 306.01,
-                "max_elevation": 399.91,
-                "xs_id": 91.32
-            },
-            "eclipsed": false,
-            "low_flow": 415074,
-            "high_flow": 1897907,
-            "network_to_id": "5089926",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 25,
-                        "std": 24,
-                        "min": 8,
-                        "25%": 17,
-                        "50%": 25,
-                        "75%": 34,
-                        "max": 43
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 79,
-                        "std": 7,
-                        "min": 73,
-                        "25%": 76,
-                        "50%": 79,
-                        "75%": 81,
-                        "max": 84
-                    }
-                },
-                "lengths": {
-                    "ras": 2680,
-                    "network": 2719,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.08,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089926",
-                    "overlap": 359
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089924"
-            ]
-        },
-        "5089920": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 287.72,
-                "max_elevation": 400.06,
-                "xs_id": 94.37
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 308.77,
-                "max_elevation": 399.97,
-                "xs_id": 91.83
-            },
-            "eclipsed": false,
-            "low_flow": 415073,
-            "high_flow": 1897871,
-            "network_to_id": "5089922",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 45,
-                        "std": 39,
-                        "min": 8,
-                        "25%": 20,
-                        "50%": 38,
-                        "75%": 51,
-                        "max": 117
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 70,
-                        "std": 43,
-                        "min": 22,
-                        "25%": 34,
-                        "50%": 75,
-                        "75%": 85,
-                        "max": 137
-                    }
-                },
-                "lengths": {
-                    "ras": 11351,
-                    "network": 11188,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.03,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089922",
-                    "overlap": 192
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089918"
-            ]
-        },
-        "5089914": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 307.17,
-                "max_elevation": 400.11,
-                "xs_id": 97.15
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 287.72,
-                "max_elevation": 400.06,
-                "xs_id": 94.37
-            },
-            "eclipsed": false,
-            "low_flow": 414997,
-            "high_flow": 1897817,
-            "network_to_id": "5089920",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 50,
-                        "std": 39,
-                        "min": 16,
-                        "25%": 18,
-                        "50%": 36,
-                        "75%": 84,
-                        "max": 100
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 231,
-                        "std": 156,
-                        "min": 24,
-                        "25%": 105,
-                        "50%": 280,
-                        "75%": 339,
-                        "max": 400
-                    }
-                },
-                "lengths": {
-                    "ras": 14469,
-                    "network": 14254,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.17,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089920",
-                    "overlap": 397
-                }
-            ],
-            "eclipsed_reaches": [
-                "5088798",
-                "5089916"
-            ]
-        },
-        "5089912": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 315.0,
-                "max_elevation": 399.97,
-                "xs_id": 106.23
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 307.17,
-                "max_elevation": 400.11,
-                "xs_id": 97.15
-            },
-            "eclipsed": false,
-            "low_flow": 414999,
-            "high_flow": 1897903,
-            "network_to_id": "5089914",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 18,
-                        "mean": 113,
-                        "std": 52,
-                        "min": 19,
-                        "25%": 88,
-                        "50%": 104,
-                        "75%": 152,
-                        "max": 197
-                    },
-                    "thalweg_offset": {
-                        "count": 18,
-                        "mean": 332,
-                        "std": 104,
-                        "min": 153,
-                        "25%": 276,
-                        "50%": 326,
-                        "75%": 397,
-                        "max": 510
-                    }
-                },
-                "lengths": {
-                    "ras": 47435,
-                    "network": 47243,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.02,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089914",
-                    "overlap": 2921
-                }
-            ],
-            "eclipsed_reaches": [
-                "5088776",
-                "5089786",
-                "5089910",
-                "5088774",
-                "5088640",
-                "5088742",
-                "5088686",
-                "5088658",
-                "5088656",
-                "5088740",
-                "5088672",
-                "5089788",
-                "5089790"
-            ]
-        },
-        "5089904": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 315.74,
-                "max_elevation": 400.13,
-                "xs_id": 109.93
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 2",
-                "min_elevation": 315.0,
-                "max_elevation": 399.97,
-                "xs_id": 106.23
-            },
-            "eclipsed": false,
-            "low_flow": 415058,
-            "high_flow": 1897827,
-            "network_to_id": "5089912",
-            "gage": "07020500",
-            "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=07020500&legacy=1",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 11,
-                        "mean": 50,
-                        "std": 25,
-                        "min": 1,
-                        "25%": 42,
-                        "50%": 53,
-                        "75%": 58,
-                        "max": 98
-                    },
-                    "thalweg_offset": {
-                        "count": 11,
-                        "mean": 144,
-                        "std": 60,
-                        "min": 12,
-                        "25%": 131,
-                        "50%": 158,
-                        "75%": 188,
-                        "max": 198
-                    }
-                },
-                "lengths": {
-                    "ras": 19363,
-                    "network": 19372,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.11,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5089912",
-                    "overlap": 1122
-                }
-            ],
-            "eclipsed_reaches": [
-                "5089902",
-                "5088632",
-                "5088630"
-            ]
-        },
-        "5092376": {
+        "5089872": {
             "eclipsed": true,
-            "low_flow": 334,
-            "high_flow": 2226,
-            "network_to_id": "5092666"
+            "low_flow": 307967,
+            "high_flow": 2273168,
+            "network_to_id": "5089868",
+            "ds_slope": 1.9999999494757503e-05
         },
-        "5092706": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 236.22,
-                "max_elevation": 337.72,
-                "xs_id": 6.25
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 254.97,
-                "max_elevation": 339.98,
-                "xs_id": 5.11
-            },
-            "eclipsed": false,
-            "low_flow": 417777,
-            "high_flow": 1869108,
-            "network_to_id": "5093440",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 77,
-                        "std": 90,
-                        "min": 24,
-                        "25%": 25,
-                        "50%": 27,
-                        "75%": 104,
-                        "max": 182
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 1646,
-                        "std": 1434,
-                        "min": 41,
-                        "25%": 1070,
-                        "50%": 2099,
-                        "75%": 2449,
-                        "max": 2799
-                    }
-                },
-                "lengths": {
-                    "ras": 5995,
-                    "network": 6023,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.13,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5093440",
-                    "overlap": 2068
-                }
-            ],
-            "eclipsed_reaches": []
+        "5088488": {
+            "eclipsed": true,
+            "low_flow": 270,
+            "high_flow": 14138,
+            "network_to_id": "5088524",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5093440": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 254.97,
-                "max_elevation": 339.98,
-                "xs_id": 5.11
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 260.61,
-                "max_elevation": 336.55,
-                "xs_id": 4.58
-            },
-            "eclipsed": false,
-            "low_flow": 417772,
-            "high_flow": 1869041,
-            "network_to_id": "5093450",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 103,
-                        "std": 112,
-                        "min": 23,
-                        "25%": 63,
-                        "50%": 103,
-                        "75%": 142,
-                        "max": 182
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 418,
-                        "std": 533,
-                        "min": 41,
-                        "25%": 229,
-                        "50%": 418,
-                        "75%": 606,
-                        "max": 795
-                    }
-                },
-                "lengths": {
-                    "ras": 3276,
-                    "network": 3253,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.48,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5093450",
-                    "overlap": 992
-                }
-            ],
-            "eclipsed_reaches": [
-                "5093442"
-            ]
+        "5089870": {
+            "eclipsed": true,
+            "low_flow": 311105,
+            "high_flow": 2277490,
+            "network_to_id": "5089880",
+            "ds_slope": 3.9999998989515007e-05
         },
-        "5092674": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 260.86,
-                "max_elevation": 338.911,
-                "xs_id": 11.25
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 257.6122,
-                "max_elevation": 338.911,
-                "xs_id": 9.6
-            },
-            "eclipsed": false,
-            "low_flow": 417811,
-            "high_flow": 1869283,
-            "network_to_id": "5092686",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 37,
-                        "std": 30,
-                        "min": 10,
-                        "25%": 18,
-                        "50%": 29,
-                        "75%": 47,
-                        "max": 79
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 488,
-                        "std": 274,
-                        "min": 91,
-                        "25%": 414,
-                        "50%": 592,
-                        "75%": 666,
-                        "max": 676
-                    }
-                },
-                "lengths": {
-                    "ras": 8491,
-                    "network": 8629,
-                    "network_to_ras_ratio": 1.02
-                },
-                "coverage": {
-                    "start": 0.12,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092686",
-                    "overlap": 1574
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092378",
-                "5092672"
-            ]
+        "3630817": {
+            "eclipsed": true,
+            "low_flow": 307940,
+            "high_flow": 2273156,
+            "network_to_id": "3630823",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5092696": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 255.32,
-                "max_elevation": 339.26,
-                "xs_id": 8.23
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 256.08,
-                "max_elevation": 341.92,
-                "xs_id": 7.517
-            },
-            "eclipsed": false,
-            "low_flow": 417795,
-            "high_flow": 1869127,
-            "network_to_id": "5092702",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 143,
-                        "std": 33,
-                        "min": 121,
-                        "25%": 124,
-                        "50%": 126,
-                        "75%": 153,
-                        "max": 180
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 719,
-                        "std": 924,
-                        "min": 131,
-                        "25%": 186,
-                        "50%": 242,
-                        "75%": 1013,
-                        "max": 1784
-                    }
-                },
-                "lengths": {
-                    "ras": 3088,
-                    "network": 3118,
-                    "network_to_ras_ratio": 1.01
-                },
-                "coverage": {
-                    "start": 0.58,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092702",
-                    "overlap": 146
-                }
-            ],
-            "eclipsed_reaches": []
+        "3629227": {
+            "eclipsed": true,
+            "low_flow": 307820,
+            "high_flow": 2273042,
+            "network_to_id": "3629237",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5092686": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 257.6122,
-                "max_elevation": 338.911,
-                "xs_id": 9.6
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 255.32,
-                "max_elevation": 339.26,
-                "xs_id": 8.23
-            },
-            "eclipsed": false,
-            "low_flow": 417808,
-            "high_flow": 1869280,
-            "network_to_id": "5092696",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 134,
-                        "std": 51,
-                        "min": 79,
-                        "25%": 111,
-                        "50%": 142,
-                        "75%": 161,
-                        "max": 180
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 375,
-                        "std": 141,
-                        "min": 242,
-                        "25%": 301,
-                        "50%": 360,
-                        "75%": 441,
-                        "max": 522
-                    }
-                },
-                "lengths": {
-                    "ras": 8937,
-                    "network": 8233,
-                    "network_to_ras_ratio": 0.92
-                },
-                "coverage": {
-                    "start": 0.28,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092696",
-                    "overlap": 4104
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092398",
-                "5092692"
-            ]
+        "3629209": {
+            "eclipsed": true,
+            "low_flow": 307826,
+            "high_flow": 2273359,
+            "network_to_id": "3629213",
+            "ds_slope": 0.000590000010561198
         },
-        "5092702": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 256.08,
-                "max_elevation": 341.92,
-                "xs_id": 7.517
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 236.22,
-                "max_elevation": 337.72,
-                "xs_id": 6.25
-            },
-            "eclipsed": false,
-            "low_flow": 417783,
-            "high_flow": 1869170,
-            "network_to_id": "5092706",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 6,
-                        "mean": 116,
-                        "std": 47,
-                        "min": 24,
-                        "25%": 122,
-                        "50%": 126,
-                        "75%": 144,
-                        "max": 151
-                    },
-                    "thalweg_offset": {
-                        "count": 6,
-                        "mean": 2125,
-                        "std": 513,
-                        "min": 1781,
-                        "25%": 1788,
-                        "50%": 1805,
-                        "75%": 2535,
-                        "max": 2799
-                    }
-                },
-                "lengths": {
-                    "ras": 6966,
-                    "network": 6593,
-                    "network_to_ras_ratio": 0.95
-                },
-                "coverage": {
-                    "start": 0.02,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092706",
-                    "overlap": 594
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092744",
-                "5092700",
-                "5092404"
-            ]
+        "3629203": {
+            "eclipsed": true,
+            "low_flow": 307775,
+            "high_flow": 2272976,
+            "network_to_id": "3629205",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5092660": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 248.458,
-                "max_elevation": 337.9269,
-                "xs_id": 12.2
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 260.86,
-                "max_elevation": 338.911,
-                "xs_id": 11.25
-            },
-            "eclipsed": false,
-            "low_flow": 417830,
-            "high_flow": 1869275,
-            "network_to_id": "5092674",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 3,
-                        "mean": 16,
-                        "std": 11,
-                        "min": 8,
-                        "25%": 9,
-                        "50%": 10,
-                        "75%": 20,
-                        "max": 29
-                    },
-                    "thalweg_offset": {
-                        "count": 3,
-                        "mean": 164,
-                        "std": 104,
-                        "min": 91,
-                        "25%": 104,
-                        "50%": 117,
-                        "75%": 200,
-                        "max": 283
-                    }
-                },
-                "lengths": {
-                    "ras": 5467,
-                    "network": 5490,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.35,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092674",
-                    "overlap": 1000
-                }
-            ],
-            "eclipsed_reaches": [
-                "5092662"
-            ]
+        "3629077": {
+            "eclipsed": true,
+            "low_flow": 307698,
+            "high_flow": 2276287,
+            "network_to_id": "3629083",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5092656": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 252.133,
-                "max_elevation": 340.2229,
-                "xs_id": 12.67
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 248.458,
-                "max_elevation": 337.9269,
-                "xs_id": 12.2
-            },
-            "eclipsed": false,
-            "low_flow": 417343,
-            "high_flow": 1893707,
-            "network_to_id": "5092660",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 2,
-                        "mean": 40,
-                        "std": 16,
-                        "min": 29,
-                        "25%": 34,
-                        "50%": 40,
-                        "75%": 45,
-                        "max": 51
-                    },
-                    "thalweg_offset": {
-                        "count": 2,
-                        "mean": 115,
-                        "std": 3,
-                        "min": 113,
-                        "25%": 114,
-                        "50%": 115,
-                        "75%": 116,
-                        "max": 117
-                    }
-                },
-                "lengths": {
-                    "ras": 2408,
-                    "network": 2385,
-                    "network_to_ras_ratio": 0.99
-                },
-                "coverage": {
-                    "start": 0.99,
-                    "end": 1
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5092660",
-                    "overlap": 2367
-                }
-            ],
-            "eclipsed_reaches": []
+        "3629191": {
+            "eclipsed": true,
+            "low_flow": 307773,
+            "high_flow": 2272912,
+            "network_to_id": "3629197",
+            "ds_slope": 0.002859999891370535
         },
-        "5093448": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 254.19,
-                "max_elevation": 335.68,
-                "xs_id": 2.67
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 250.24,
-                "max_elevation": 334.67,
-                "xs_id": 1.39
-            },
-            "eclipsed": false,
-            "low_flow": 417741,
-            "high_flow": 1868931,
-            "network_to_id": "5093446",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 7,
-                        "mean": 41,
-                        "std": 60,
-                        "min": 15,
-                        "25%": 18,
-                        "50%": 19,
-                        "75%": 20,
-                        "max": 178
-                    },
-                    "thalweg_offset": {
-                        "count": 7,
-                        "mean": 509,
-                        "std": 224,
-                        "min": 95,
-                        "25%": 423,
-                        "50%": 590,
-                        "75%": 615,
-                        "max": 799
-                    }
-                },
-                "lengths": {
-                    "ras": 6724,
-                    "network": 6754,
-                    "network_to_ras_ratio": 1.0
-                },
-                "coverage": {
-                    "start": 0.0,
-                    "end": 0.73
-                }
-            },
-            "overlapped_reaches": [],
-            "eclipsed_reaches": []
+        "3629319": {
+            "eclipsed": true,
+            "low_flow": 307755,
+            "high_flow": 2273037,
+            "network_to_id": "3629183",
+            "ds_slope": 9.999999747378752e-06
         },
-        "5093450": {
-            "us_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 260.61,
-                "max_elevation": 336.55,
-                "xs_id": 4.58
-            },
-            "ds_xs": {
-                "river": "Mississippi",
-                "reach": "Reach 3",
-                "min_elevation": 254.19,
-                "max_elevation": 335.68,
-                "xs_id": 2.67
-            },
-            "eclipsed": false,
-            "low_flow": 417743,
-            "high_flow": 1869007,
-            "network_to_id": "5093448",
-            "metrics": {
-                "xs": {
-                    "centerline_offset": {
-                        "count": 4,
-                        "mean": 75,
-                        "std": 78,
-                        "min": 6,
-                        "25%": 19,
-                        "50%": 59,
-                        "75%": 115,
-                        "max": 178
-                    },
-                    "thalweg_offset": {
-                        "count": 4,
-                        "mean": 452,
-                        "std": 381,
-                        "min": 95,
-                        "25%": 136,
-                        "50%": 459,
-                        "75%": 774,
-                        "max": 795
-                    }
-                },
-                "lengths": {
-                    "ras": 10309,
-                    "network": 10111,
-                    "network_to_ras_ratio": 0.98
-                },
-                "coverage": {
-                    "start": 0.09,
-                    "end": 1.0
-                }
-            },
-            "overlapped_reaches": [
-                {
-                    "id": "5093448",
-                    "overlap": 8
-                }
-            ],
-            "eclipsed_reaches": [
-                "5093180",
-                "5093452"
-            ]
+        "3629183": {
+            "eclipsed": true,
+            "low_flow": 307755,
+            "high_flow": 2273085,
+            "network_to_id": "3629187",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2927571": {
+            "eclipsed": true,
+            "low_flow": 128524,
+            "high_flow": 927049,
+            "network_to_id": "2927581",
+            "ds_slope": 0.0038499999791383743
+        },
+        "2927711": {
+            "eclipsed": true,
+            "low_flow": 128521,
+            "high_flow": 926908,
+            "network_to_id": "2927597",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2927727": {
+            "eclipsed": true,
+            "low_flow": 128523,
+            "high_flow": 926966,
+            "network_to_id": "2927713",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2927697": {
+            "eclipsed": true,
+            "low_flow": 128519,
+            "high_flow": 926854,
+            "network_to_id": "2927689",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2927613": {
+            "eclipsed": true,
+            "low_flow": 128517,
+            "high_flow": 926772,
+            "network_to_id": "2927667",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2932231": {
+            "eclipsed": true,
+            "low_flow": 128515,
+            "high_flow": 926722,
+            "network_to_id": "2932165",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2932209": {
+            "eclipsed": true,
+            "low_flow": 128515,
+            "high_flow": 926732,
+            "network_to_id": "2932171",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930907": {
+            "eclipsed": true,
+            "low_flow": 129119,
+            "high_flow": 940332,
+            "network_to_id": "2930909",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930569": {
+            "eclipsed": true,
+            "low_flow": 129119,
+            "high_flow": 940362,
+            "network_to_id": "2930577",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930887": {
+            "eclipsed": true,
+            "low_flow": 129119,
+            "high_flow": 940347,
+            "network_to_id": "2930565",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930565": {
+            "eclipsed": true,
+            "low_flow": 129119,
+            "high_flow": 940365,
+            "network_to_id": "2931051",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930889": {
+            "eclipsed": true,
+            "low_flow": 129119,
+            "high_flow": 940386,
+            "network_to_id": "2930905",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930543": {
+            "eclipsed": true,
+            "low_flow": 129119,
+            "high_flow": 940541,
+            "network_to_id": "2930875",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930771": {
+            "eclipsed": true,
+            "low_flow": 129184,
+            "high_flow": 932743,
+            "network_to_id": "2932865",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2932865": {
+            "eclipsed": true,
+            "low_flow": 129184,
+            "high_flow": 932769,
+            "network_to_id": "2932869",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2938441": {
+            "eclipsed": true,
+            "low_flow": 129195,
+            "high_flow": 933511,
+            "network_to_id": "2938445",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930761": {
+            "eclipsed": true,
+            "low_flow": 129183,
+            "high_flow": 933405,
+            "network_to_id": "2930763",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2938455": {
+            "eclipsed": true,
+            "low_flow": 129189,
+            "high_flow": 933526,
+            "network_to_id": "2930679",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2938477": {
+            "eclipsed": true,
+            "low_flow": 129188,
+            "high_flow": 933480,
+            "network_to_id": "2930719",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2931017": {
+            "eclipsed": true,
+            "low_flow": 129188,
+            "high_flow": 933458,
+            "network_to_id": "2930981",
+            "ds_slope": 1.9999999494757503e-05
+        },
+        "2932875": {
+            "eclipsed": true,
+            "low_flow": 129183,
+            "high_flow": 932749,
+            "network_to_id": "2932881",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2938485": {
+            "eclipsed": true,
+            "low_flow": 129188,
+            "high_flow": 933484,
+            "network_to_id": "2930723",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "2930625": {
+            "eclipsed": true,
+            "low_flow": 129194,
+            "high_flow": 933522,
+            "network_to_id": "2938449",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "880644": {
+            "eclipsed": true,
+            "low_flow": 129323,
+            "high_flow": 939408,
+            "network_to_id": "880668",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "880478": {
+            "eclipsed": true,
+            "low_flow": 184040,
+            "high_flow": 1034822,
+            "network_to_id": "880484",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "882688": {
+            "eclipsed": true,
+            "low_flow": 184039,
+            "high_flow": 1034897,
+            "network_to_id": "880512",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "880814": {
+            "eclipsed": true,
+            "low_flow": 184037,
+            "high_flow": 1035119,
+            "network_to_id": "880562",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "880608": {
+            "eclipsed": true,
+            "low_flow": 0,
+            "high_flow": 1022836,
+            "network_to_id": "880618",
+            "ds_slope": 9.999999747378752e-06
         }
     },
     "metadata": {
         "source_network": {
             "file_name": "flows.parquet",
-            "version": "2.1",
-            "type": "nwm_hydrofabric"
+            "type": "nwm_hydrofabric",
+            "version": "2.1"
         },
-        "conflation_png": "MissFldwy.conflation.png",
-        "conflation_ripple1d_version": "0.4.2",
-        "metrics_ripple1d_version": "0.4.2",
+        "conflation_ripple1d_version": "0.10.4",
+        "metrics_ripple1d_version": "0.10.4",
         "source_ras_model": {
             "stac_api": "https://stac2.dewberryanalytics.com",
             "stac_collection_id": "ebfe-12090301_LowerColoradoCummins",
             "stac_item_id": "137a9667-e5cf-4cea-b6ec-2e882a42fdc8",
+            "units": "English",
             "source_ras_files": {
                 "geometry": "MissFldwy.g01",
                 "forcing": "MissFldwy.f01",

--- a/tests/ras-data/PatuxentRiver/PatuxentRiver.conflation.json
+++ b/tests/ras-data/PatuxentRiver/PatuxentRiver.conflation.json
@@ -19,7 +19,7 @@
             "low_flow": 1519,
             "high_flow": 23963,
             "network_to_id": "11908588",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908588",
             "metrics": {
                 "xs": {
@@ -81,7 +81,7 @@
             "low_flow": 737,
             "high_flow": 7938,
             "network_to_id": "11908292",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 0.00054,
             "ds_slope_source_nwm_id": "11908292",
             "metrics": {
                 "xs": {
@@ -143,7 +143,7 @@
             "low_flow": 720,
             "high_flow": 6741,
             "network_to_id": "11907736",
-            "ds_slope": 0.0008900000248104334,
+            "ds_slope": 0.00089,
             "ds_slope_source_nwm_id": "11907736",
             "metrics": {
                 "xs": {
@@ -205,7 +205,7 @@
             "low_flow": 697,
             "high_flow": 6604,
             "network_to_id": "11906060",
-            "ds_slope": 0.0007800000021234155,
+            "ds_slope": 0.00078,
             "ds_slope_source_nwm_id": "11907726",
             "metrics": {
                 "xs": {
@@ -269,7 +269,7 @@
             "low_flow": 647,
             "high_flow": 5567,
             "network_to_id": "11906036",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11906036",
             "metrics": {
                 "xs": {
@@ -331,7 +331,7 @@
             "low_flow": 630,
             "high_flow": 5550,
             "network_to_id": "11905994",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 0.00054,
             "ds_slope_source_nwm_id": "11905994",
             "metrics": {
                 "xs": {
@@ -393,7 +393,7 @@
             "low_flow": 627,
             "high_flow": 5777,
             "network_to_id": "11906282",
-            "ds_slope": 0.001180000021122396,
+            "ds_slope": 0.00118,
             "ds_slope_source_nwm_id": "11906282",
             "metrics": {
                 "xs": {
@@ -455,7 +455,7 @@
             "low_flow": 626,
             "high_flow": 5748,
             "network_to_id": "11906276",
-            "ds_slope": 0.0022700000554323196,
+            "ds_slope": 0.00227,
             "ds_slope_source_nwm_id": "11906276",
             "metrics": {
                 "xs": {
@@ -517,7 +517,7 @@
             "low_flow": 624,
             "high_flow": 5729,
             "network_to_id": "11905958",
-            "ds_slope": 0.0038799999747425318,
+            "ds_slope": 0.00388,
             "ds_slope_source_nwm_id": "11905958",
             "metrics": {
                 "xs": {
@@ -579,7 +579,7 @@
             "low_flow": 630,
             "high_flow": 5881,
             "network_to_id": "11906270",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11906270",
             "metrics": {
                 "xs": {
@@ -641,7 +641,7 @@
             "low_flow": 632,
             "high_flow": 5903,
             "network_to_id": "11905918",
-            "ds_slope": 0.003869999898597598,
+            "ds_slope": 0.00387,
             "ds_slope_source_nwm_id": "11905918",
             "metrics": {
                 "xs": {
@@ -703,7 +703,7 @@
             "low_flow": 625,
             "high_flow": 5823,
             "network_to_id": "11905848",
-            "ds_slope": 0.0019600000232458115,
+            "ds_slope": 0.00196,
             "ds_slope_source_nwm_id": "11906232",
             "metrics": {
                 "xs": {
@@ -767,7 +767,7 @@
             "low_flow": 626,
             "high_flow": 5775,
             "network_to_id": "11905836",
-            "ds_slope": 0.0010100000072270632,
+            "ds_slope": 0.00101,
             "ds_slope_source_nwm_id": "11905844",
             "metrics": {
                 "xs": {
@@ -831,7 +831,7 @@
             "low_flow": 627,
             "high_flow": 5899,
             "network_to_id": "11905838",
-            "ds_slope": 0.0012100000167265534,
+            "ds_slope": 0.00121,
             "ds_slope_source_nwm_id": "11905838",
             "metrics": {
                 "xs": {
@@ -893,7 +893,7 @@
             "low_flow": 627,
             "high_flow": 5742,
             "network_to_id": "11906208",
-            "ds_slope": 0.00022000000171829015,
+            "ds_slope": 0.00022,
             "ds_slope_source_nwm_id": "11906208",
             "metrics": {
                 "xs": {
@@ -955,7 +955,7 @@
             "low_flow": 607,
             "high_flow": 5289,
             "network_to_id": "11905834",
-            "ds_slope": 0.00022000000171829015,
+            "ds_slope": 0.00022,
             "ds_slope_source_nwm_id": "11906208",
             "metrics": {
                 "xs": {
@@ -1021,7 +1021,7 @@
             "low_flow": 585,
             "high_flow": 4501,
             "network_to_id": "11905828",
-            "ds_slope": 0.0002500000118743628,
+            "ds_slope": 0.00025,
             "ds_slope_source_nwm_id": "11905828",
             "metrics": {
                 "xs": {
@@ -1083,7 +1083,7 @@
             "low_flow": 312,
             "high_flow": 2506,
             "network_to_id": "11905820",
-            "ds_slope": 0.0016599999507889152,
+            "ds_slope": 0.00166,
             "ds_slope_source_nwm_id": "11905820",
             "metrics": {
                 "xs": {
@@ -1145,7 +1145,7 @@
             "low_flow": 304,
             "high_flow": 2554,
             "network_to_id": "11906198",
-            "ds_slope": 0.0023399998899549246,
+            "ds_slope": 0.00234,
             "ds_slope_source_nwm_id": "11906198",
             "metrics": {
                 "xs": {
@@ -1207,7 +1207,7 @@
             "low_flow": 300,
             "high_flow": 2812,
             "network_to_id": "11906196",
-            "ds_slope": 0.001769999973475933,
+            "ds_slope": 0.00177,
             "ds_slope_source_nwm_id": "11906196",
             "metrics": {
                 "xs": {
@@ -1269,7 +1269,7 @@
             "low_flow": 321,
             "high_flow": 3082,
             "network_to_id": "11905796",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11905796",
             "metrics": {
                 "xs": {
@@ -1331,7 +1331,7 @@
             "low_flow": 213,
             "high_flow": 1802,
             "network_to_id": "11906190",
-            "ds_slope": 0.0012000000569969416,
+            "ds_slope": 0.0012,
             "ds_slope_source_nwm_id": "11906190",
             "metrics": {
                 "xs": {
@@ -1395,7 +1395,7 @@
             "network_to_id": "11905756",
             "gage": "01592500",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=01592500&legacy=1",
-            "ds_slope": 0.005210000090301037,
+            "ds_slope": 0.00521,
             "ds_slope_source_nwm_id": "11905756",
             "metrics": {
                 "xs": {
@@ -1457,7 +1457,7 @@
             "low_flow": 629,
             "high_flow": 5476,
             "network_to_id": "11906000",
-            "ds_slope": 0.0016199999954551458,
+            "ds_slope": 0.00162,
             "ds_slope_source_nwm_id": "11906304",
             "metrics": {
                 "xs": {
@@ -1521,7 +1521,7 @@
             "low_flow": 630,
             "high_flow": 5643,
             "network_to_id": "11906290",
-            "ds_slope": 0.0008500000112690032,
+            "ds_slope": 0.00085,
             "ds_slope_source_nwm_id": "11906290",
             "metrics": {
                 "xs": {
@@ -1583,7 +1583,7 @@
             "low_flow": 626,
             "high_flow": 5436,
             "network_to_id": "11906034",
-            "ds_slope": 0.0007300000288523734,
+            "ds_slope": 0.00073,
             "ds_slope_source_nwm_id": "11906034",
             "metrics": {
                 "xs": {
@@ -1645,7 +1645,7 @@
             "low_flow": 646,
             "high_flow": 5523,
             "network_to_id": "11906038",
-            "ds_slope": 0.002859999891370535,
+            "ds_slope": 0.00286,
             "ds_slope_source_nwm_id": "11906046",
             "metrics": {
                 "xs": {
@@ -1709,7 +1709,7 @@
             "low_flow": 638,
             "high_flow": 5983,
             "network_to_id": "11906240",
-            "ds_slope": 0.0003600000054575503,
+            "ds_slope": 0.00036,
             "ds_slope_source_nwm_id": "11906240",
             "metrics": {
                 "xs": {
@@ -1771,7 +1771,7 @@
             "low_flow": 623,
             "high_flow": 5551,
             "network_to_id": "11905984",
-            "ds_slope": 0.0026000000070780516,
+            "ds_slope": 0.0026,
             "ds_slope_source_nwm_id": "11905984",
             "metrics": {
                 "xs": {
@@ -1833,7 +1833,7 @@
             "low_flow": 694,
             "high_flow": 6420,
             "network_to_id": "11906328",
-            "ds_slope": 0.0009599999757483602,
+            "ds_slope": 0.00096,
             "ds_slope_source_nwm_id": "11906328",
             "metrics": {
                 "xs": {
@@ -1895,7 +1895,7 @@
             "low_flow": 687,
             "high_flow": 6102,
             "network_to_id": "11906048",
-            "ds_slope": 0.0014900000533089042,
+            "ds_slope": 0.00149,
             "ds_slope_source_nwm_id": "11906048",
             "metrics": {
                 "xs": {
@@ -1957,7 +1957,7 @@
             "low_flow": 628,
             "high_flow": 5516,
             "network_to_id": "11906030",
-            "ds_slope": 0.0002699999895412475,
+            "ds_slope": 0.00027,
             "ds_slope_source_nwm_id": "11906030",
             "metrics": {
                 "xs": {
@@ -2019,7 +2019,7 @@
             "low_flow": 628,
             "high_flow": 5576,
             "network_to_id": "11905990",
-            "ds_slope": 0.0007399999885819852,
+            "ds_slope": 0.00074,
             "ds_slope_source_nwm_id": "11905990",
             "metrics": {
                 "xs": {
@@ -2081,7 +2081,7 @@
             "low_flow": 619,
             "high_flow": 5711,
             "network_to_id": "11905974",
-            "ds_slope": 0.002050000010058284,
+            "ds_slope": 0.00205,
             "ds_slope_source_nwm_id": "11905976",
             "metrics": {
                 "xs": {
@@ -2145,7 +2145,7 @@
             "low_flow": 633,
             "high_flow": 5914,
             "network_to_id": "11905886",
-            "ds_slope": 0.0008900000248104334,
+            "ds_slope": 0.00089,
             "ds_slope_source_nwm_id": "11905914",
             "metrics": {
                 "xs": {
@@ -2209,7 +2209,7 @@
             "low_flow": 1523,
             "high_flow": 22888,
             "network_to_id": "11908594",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908588",
             "metrics": {
                 "xs": {
@@ -2266,7 +2266,7 @@
             "low_flow": 1513,
             "high_flow": 24987,
             "network_to_id": "11908578",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908582",
             "metrics": {
                 "xs": {
@@ -2330,7 +2330,7 @@
             "low_flow": 1524,
             "high_flow": 25603,
             "network_to_id": "11908576",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908576",
             "metrics": {
                 "xs": {
@@ -2392,7 +2392,7 @@
             "low_flow": 1524,
             "high_flow": 25642,
             "network_to_id": "11908566",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908566",
             "metrics": {
                 "xs": {
@@ -2454,7 +2454,7 @@
             "low_flow": 1525,
             "high_flow": 25674,
             "network_to_id": "11908572",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908572",
             "metrics": {
                 "xs": {
@@ -2516,7 +2516,7 @@
             "low_flow": 1523,
             "high_flow": 25815,
             "network_to_id": "11908554",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908554",
             "metrics": {
                 "xs": {
@@ -2578,7 +2578,7 @@
             "low_flow": 1518,
             "high_flow": 25520,
             "network_to_id": "11908560",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908560",
             "metrics": {
                 "xs": {
@@ -2640,7 +2640,7 @@
             "low_flow": 1518,
             "high_flow": 25315,
             "network_to_id": "11908562",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908562",
             "metrics": {
                 "xs": {
@@ -2702,7 +2702,7 @@
             "low_flow": 1511,
             "high_flow": 24779,
             "network_to_id": "11907892",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11907892",
             "metrics": {
                 "xs": {
@@ -2764,7 +2764,7 @@
             "low_flow": 1523,
             "high_flow": 27264,
             "network_to_id": "11907880",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11907880",
             "metrics": {
                 "xs": {
@@ -2826,7 +2826,7 @@
             "low_flow": 1513,
             "high_flow": 27213,
             "network_to_id": "11907860",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11907860",
             "metrics": {
                 "xs": {
@@ -2888,7 +2888,7 @@
             "low_flow": 1513,
             "high_flow": 27120,
             "network_to_id": "11907854",
-            "ds_slope": 0.0048699998296797276,
+            "ds_slope": 0.00487,
             "ds_slope_source_nwm_id": "11907854",
             "metrics": {
                 "xs": {
@@ -2950,7 +2950,7 @@
             "low_flow": 1485,
             "high_flow": 27400,
             "network_to_id": "11907848",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11907848",
             "metrics": {
                 "xs": {
@@ -3012,7 +3012,7 @@
             "low_flow": 1474,
             "high_flow": 27379,
             "network_to_id": "11907838",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11907838",
             "metrics": {
                 "xs": {
@@ -3074,7 +3074,7 @@
             "low_flow": 1517,
             "high_flow": 29428,
             "network_to_id": "11907832",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11907832",
             "metrics": {
                 "xs": {
@@ -3136,7 +3136,7 @@
             "low_flow": 1543,
             "high_flow": 30121,
             "network_to_id": "11907806",
-            "ds_slope": 0.00033999999868683517,
+            "ds_slope": 0.00034,
             "ds_slope_source_nwm_id": "11907806",
             "metrics": {
                 "xs": {
@@ -3198,7 +3198,7 @@
             "low_flow": 1517,
             "high_flow": 29907,
             "network_to_id": "11907774",
-            "ds_slope": 0.0005000000237487257,
+            "ds_slope": 0.0005,
             "ds_slope_source_nwm_id": "11907782",
             "metrics": {
                 "xs": {
@@ -3262,7 +3262,7 @@
             "low_flow": 1531,
             "high_flow": 31046,
             "network_to_id": "11908324",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908324",
             "metrics": {
                 "xs": {
@@ -3324,7 +3324,7 @@
             "low_flow": 1563,
             "high_flow": 35039,
             "network_to_id": "11907764",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "11908316",
             "metrics": {
                 "xs": {
@@ -3390,7 +3390,7 @@
             "network_to_id": "11907762",
             "gage": "01594440",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=01594440&legacy=1",
-            "ds_slope": 0.00011000000085914508,
+            "ds_slope": 0.00011,
             "ds_slope_source_nwm_id": "11907762",
             "metrics": {
                 "xs": {
@@ -3452,7 +3452,7 @@
             "low_flow": 1565,
             "high_flow": 36606,
             "network_to_id": "11907758",
-            "ds_slope": 0.0001500000071246177,
+            "ds_slope": 0.00015,
             "ds_slope_source_nwm_id": "11907758",
             "metrics": {
                 "xs": {
@@ -3514,7 +3514,7 @@
             "low_flow": 1563,
             "high_flow": 37789,
             "network_to_id": "11907746",
-            "ds_slope": 0.0008299999753944576,
+            "ds_slope": 0.00083,
             "ds_slope_source_nwm_id": "11907746",
             "metrics": {
                 "xs": {
@@ -3576,7 +3576,7 @@
             "low_flow": 1560,
             "high_flow": 37371,
             "network_to_id": "11908300",
-            "ds_slope": 0.00023999999393709004,
+            "ds_slope": 0.00024,
             "ds_slope_source_nwm_id": "11908300",
             "metrics": {
                 "xs": {
@@ -3638,7 +3638,7 @@
             "low_flow": 1562,
             "high_flow": 36952,
             "network_to_id": "11908298",
-            "ds_slope": 0.0009200000204145908,
+            "ds_slope": 0.00092,
             "ds_slope_source_nwm_id": "11908298",
             "metrics": {
                 "xs": {

--- a/tests/ras-data/PatuxentRiver/PatuxentRiver.conflation.json
+++ b/tests/ras-data/PatuxentRiver/PatuxentRiver.conflation.json
@@ -16,9 +16,10 @@
                 "xs_id": 26469.46
             },
             "eclipsed": false,
-            "low_flow": 2025,
-            "high_flow": 19969,
+            "low_flow": 1519,
+            "high_flow": 23963,
             "network_to_id": "11908588",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -58,10 +59,7 @@
                     "overlap": 757
                 }
             ],
-            "eclipsed_reaches": [
-                "11908584",
-                "11908586"
-            ]
+            "eclipsed_reaches": []
         },
         "11907736": {
             "us_xs": {
@@ -79,9 +77,10 @@
                 "xs_id": 118899.1
             },
             "eclipsed": false,
-            "low_flow": 983,
-            "high_flow": 6615,
+            "low_flow": 737,
+            "high_flow": 7938,
             "network_to_id": "11908292",
+            "ds_slope": 0.0008900000248104334,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -121,15 +120,7 @@
                     "overlap": 299
                 }
             ],
-            "eclipsed_reaches": [
-                "11907734"
-            ]
-        },
-        "11906060": {
-            "eclipsed": true,
-            "low_flow": 931,
-            "high_flow": 5365,
-            "network_to_id": "11907726"
+            "eclipsed_reaches": []
         },
         "11907726": {
             "us_xs": {
@@ -147,9 +138,10 @@
                 "xs_id": 122117.8
             },
             "eclipsed": false,
-            "low_flow": 961,
-            "high_flow": 5617,
+            "low_flow": 720,
+            "high_flow": 6741,
             "network_to_id": "11907736",
+            "ds_slope": 0.0007800000021234155,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -207,9 +199,10 @@
                 "xs_id": 127390.9
             },
             "eclipsed": false,
-            "low_flow": 930,
-            "high_flow": 5503,
+            "low_flow": 697,
+            "high_flow": 6604,
             "network_to_id": "11906060",
+            "ds_slope": 0.0009599999757483602,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -269,9 +262,10 @@
                 "xs_id": 136140.3
             },
             "eclipsed": false,
-            "low_flow": 863,
-            "high_flow": 4639,
+            "low_flow": 647,
+            "high_flow": 5567,
             "network_to_id": "11906036",
+            "ds_slope": 0.0007300000288523734,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -313,12 +307,6 @@
             ],
             "eclipsed_reaches": []
         },
-        "11906000": {
-            "eclipsed": true,
-            "low_flow": 838,
-            "high_flow": 4552,
-            "network_to_id": "11906304"
-        },
         "11905990": {
             "us_xs": {
                 "river": "Patuxent River",
@@ -335,9 +323,10 @@
                 "xs_id": 148278.9
             },
             "eclipsed": false,
-            "low_flow": 840,
-            "high_flow": 4625,
+            "low_flow": 630,
+            "high_flow": 5550,
             "network_to_id": "11905994",
+            "ds_slope": 0.0007399999885819852,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -395,9 +384,10 @@
                 "xs_id": 161033.5
             },
             "eclipsed": false,
-            "low_flow": 836,
-            "high_flow": 4814,
+            "low_flow": 627,
+            "high_flow": 5777,
             "network_to_id": "11906282",
+            "ds_slope": 0.0022700000554323196,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -437,10 +427,7 @@
                     "overlap": 1025
                 }
             ],
-            "eclipsed_reaches": [
-                "11906444",
-                "11906278"
-            ]
+            "eclipsed_reaches": []
         },
         "11905958": {
             "us_xs": {
@@ -458,9 +445,10 @@
                 "xs_id": 163384.4
             },
             "eclipsed": false,
-            "low_flow": 835,
-            "high_flow": 4790,
+            "low_flow": 626,
+            "high_flow": 5748,
             "network_to_id": "11906276",
+            "ds_slope": 0.0038799999747425318,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -500,10 +488,7 @@
                     "overlap": 373
                 }
             ],
-            "eclipsed_reaches": [
-                "11906424",
-                "11906426"
-            ]
+            "eclipsed_reaches": []
         },
         "11906270": {
             "us_xs": {
@@ -521,9 +506,10 @@
                 "xs_id": 164309.7
             },
             "eclipsed": false,
-            "low_flow": 833,
-            "high_flow": 4774,
+            "low_flow": 624,
+            "high_flow": 5729,
             "network_to_id": "11905958",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -563,9 +549,7 @@
                     "overlap": 190
                 }
             ],
-            "eclipsed_reaches": [
-                "11906274"
-            ]
+            "eclipsed_reaches": []
         },
         "11905918": {
             "us_xs": {
@@ -583,9 +567,10 @@
                 "xs_id": 165339.0
             },
             "eclipsed": false,
-            "low_flow": 841,
-            "high_flow": 4901,
+            "low_flow": 630,
+            "high_flow": 5881,
             "network_to_id": "11906270",
+            "ds_slope": 0.003869999898597598,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -643,9 +628,10 @@
                 "xs_id": 166384.6
             },
             "eclipsed": false,
-            "low_flow": 842,
-            "high_flow": 4919,
+            "low_flow": 632,
+            "high_flow": 5903,
             "network_to_id": "11905918",
+            "ds_slope": 0.0008900000248104334,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -685,21 +671,7 @@
                     "overlap": 743
                 }
             ],
-            "eclipsed_reaches": [
-                "11905910"
-            ]
-        },
-        "11905886": {
-            "eclipsed": true,
-            "low_flow": 846,
-            "high_flow": 4954,
-            "network_to_id": "11905914"
-        },
-        "11905848": {
-            "eclipsed": true,
-            "low_flow": 832,
-            "high_flow": 4814,
-            "network_to_id": "11906232"
+            "eclipsed_reaches": []
         },
         "11905844": {
             "us_xs": {
@@ -717,9 +689,10 @@
                 "xs_id": 176090.0
             },
             "eclipsed": false,
-            "low_flow": 833,
-            "high_flow": 4852,
+            "low_flow": 625,
+            "high_flow": 5823,
             "network_to_id": "11905848",
+            "ds_slope": 0.0010100000072270632,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -760,16 +733,8 @@
                 }
             ],
             "eclipsed_reaches": [
-                "11905848",
-                "11905854",
-                "11905856"
+                "11905848"
             ]
-        },
-        "11905836": {
-            "eclipsed": true,
-            "low_flow": 836,
-            "high_flow": 4799,
-            "network_to_id": "11905844"
         },
         "11905838": {
             "us_xs": {
@@ -787,9 +752,10 @@
                 "xs_id": 180215.6
             },
             "eclipsed": false,
-            "low_flow": 835,
-            "high_flow": 4812,
+            "low_flow": 626,
+            "high_flow": 5775,
             "network_to_id": "11905836",
+            "ds_slope": 0.0012100000167265534,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -837,9 +803,9 @@
             "us_xs": {
                 "river": "Patuxent River",
                 "reach": "1",
-                "min_elevation": 102.33,
-                "max_elevation": 130.77,
-                "xs_id": 185454.7
+                "min_elevation": 104.76,
+                "max_elevation": 137.29,
+                "xs_id": 187454.7
             },
             "ds_xs": {
                 "river": "Patuxent River",
@@ -849,39 +815,40 @@
                 "xs_id": 183459.5
             },
             "eclipsed": false,
-            "low_flow": 836,
-            "high_flow": 4915,
+            "low_flow": 627,
+            "high_flow": 5899,
             "network_to_id": "11905838",
+            "ds_slope": 0.00022000000171829015,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 4,
-                        "mean": 78,
-                        "std": 98,
+                        "count": 10,
+                        "mean": 155,
+                        "std": 88,
                         "min": 11,
-                        "25%": 23,
-                        "50%": 39,
-                        "75%": 94,
-                        "max": 223
+                        "25%": 84,
+                        "50%": 197,
+                        "75%": 215,
+                        "max": 237
                     },
                     "thalweg_offset": {
-                        "count": 4,
-                        "mean": 76,
-                        "std": 99,
+                        "count": 10,
+                        "mean": 158,
+                        "std": 92,
                         "min": 15,
-                        "25%": 15,
-                        "50%": 32,
-                        "75%": 93,
-                        "max": 223
+                        "25%": 86,
+                        "50%": 203,
+                        "75%": 220,
+                        "max": 239
                     }
                 },
                 "lengths": {
-                    "ras": 1988,
-                    "network": 825,
-                    "network_to_ras_ratio": 0.42
+                    "ras": 4000,
+                    "network": null,
+                    "network_to_ras_ratio": null
                 },
                 "coverage": {
-                    "start": 0.81,
+                    "start": 1.03,
                     "end": 1
                 }
             },
@@ -891,9 +858,7 @@
                     "overlap": 120
                 }
             ],
-            "eclipsed_reaches": [
-                "11905832"
-            ]
+            "eclipsed_reaches": []
         },
         "11905834": {
             "us_xs": {
@@ -911,9 +876,10 @@
                 "xs_id": 183710.5
             },
             "eclipsed": false,
-            "low_flow": 836,
-            "high_flow": 4785,
+            "low_flow": 627,
+            "high_flow": 5742,
             "network_to_id": "11906208",
+            "ds_slope": 0.0017600000137463212,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -939,11 +905,11 @@
                 },
                 "lengths": {
                     "ras": 3287,
-                    "network": 6323,
-                    "network_to_ras_ratio": 1.92
+                    "network": null,
+                    "network_to_ras_ratio": null
                 },
                 "coverage": {
-                    "start": 0.0,
+                    "start": 2.33,
                     "end": 1
                 }
             },
@@ -971,9 +937,10 @@
                 "xs_id": 186994.1
             },
             "eclipsed": false,
-            "low_flow": 809,
-            "high_flow": 4408,
+            "low_flow": 607,
+            "high_flow": 5289,
             "network_to_id": "11905834",
+            "ds_slope": 0.0002500000118743628,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -999,18 +966,22 @@
                 },
                 "lengths": {
                     "ras": 2019,
-                    "network": 2057,
-                    "network_to_ras_ratio": 1.02
+                    "network": null,
+                    "network_to_ras_ratio": null
                 },
                 "coverage": {
                     "start": 0.11,
-                    "end": 1.0
+                    "end": 0.11
                 }
             },
             "overlapped_reaches": [
                 {
                     "id": "11906208",
                     "overlap": 644
+                },
+                {
+                    "id": "11905834",
+                    "overlap": 4
                 }
             ],
             "eclipsed_reaches": []
@@ -1019,9 +990,9 @@
             "us_xs": {
                 "river": "Patuxent River",
                 "reach": "1",
-                "min_elevation": 112.1,
-                "max_elevation": 141.7,
-                "xs_id": 192514.9
+                "min_elevation": 112.3,
+                "max_elevation": 146.72,
+                "xs_id": 193176.6
             },
             "ds_xs": {
                 "river": "Patuxent River",
@@ -1031,39 +1002,40 @@
                 "xs_id": 189009.2
             },
             "eclipsed": false,
-            "low_flow": 780,
-            "high_flow": 3751,
+            "low_flow": 585,
+            "high_flow": 4501,
             "network_to_id": "11905828",
+            "ds_slope": 0.0016599999507889152,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
-                        "count": 5,
-                        "mean": 28,
-                        "std": 12,
-                        "min": 15,
-                        "25%": 24,
-                        "50%": 27,
+                        "count": 6,
+                        "mean": 24,
+                        "std": 15,
+                        "min": 3,
+                        "25%": 17,
+                        "50%": 26,
                         "75%": 28,
                         "max": 47
                     },
                     "thalweg_offset": {
-                        "count": 5,
-                        "mean": 258,
-                        "std": 154,
-                        "min": 53,
-                        "25%": 158,
-                        "50%": 272,
-                        "75%": 383,
-                        "max": 422
+                        "count": 6,
+                        "mean": 27,
+                        "std": 17,
+                        "min": 4,
+                        "25%": 17,
+                        "50%": 30,
+                        "75%": 33,
+                        "max": 53
                     }
                 },
                 "lengths": {
-                    "ras": 3524,
-                    "network": 3416,
-                    "network_to_ras_ratio": 0.97
+                    "ras": 4188,
+                    "network": 4030,
+                    "network_to_ras_ratio": 0.96
                 },
                 "coverage": {
-                    "start": 0.16,
+                    "start": 0.0,
                     "end": 1
                 }
             },
@@ -1091,9 +1063,10 @@
                 "xs_id": 193176.6
             },
             "eclipsed": false,
-            "low_flow": 416,
-            "high_flow": 2088,
+            "low_flow": 312,
+            "high_flow": 2506,
             "network_to_id": "11905820",
+            "ds_slope": 0.0023399998899549246,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1133,9 +1106,7 @@
                     "overlap": 3
                 }
             ],
-            "eclipsed_reaches": [
-                "11905808"
-            ]
+            "eclipsed_reaches": []
         },
         "11906196": {
             "us_xs": {
@@ -1153,9 +1124,10 @@
                 "xs_id": 193854.4
             },
             "eclipsed": false,
-            "low_flow": 406,
-            "high_flow": 2128,
+            "low_flow": 304,
+            "high_flow": 2554,
             "network_to_id": "11906198",
+            "ds_slope": 0.001769999973475933,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1213,9 +1185,10 @@
                 "xs_id": 194817.8
             },
             "eclipsed": false,
-            "low_flow": 400,
-            "high_flow": 2343,
+            "low_flow": 300,
+            "high_flow": 2812,
             "network_to_id": "11906196",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1273,9 +1246,10 @@
                 "xs_id": 195583.1
             },
             "eclipsed": false,
-            "low_flow": 428,
-            "high_flow": 2568,
+            "low_flow": 321,
+            "high_flow": 3082,
             "network_to_id": "11905796",
+            "ds_slope": 0.0012000000569969416,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1290,13 +1264,13 @@
                     },
                     "thalweg_offset": {
                         "count": 26,
-                        "mean": 131,
-                        "std": 316,
+                        "mean": 19,
+                        "std": 20,
                         "min": 1,
-                        "25%": 10,
-                        "50%": 16,
-                        "75%": 27,
-                        "max": 1036
+                        "25%": 9,
+                        "50%": 14,
+                        "75%": 23,
+                        "max": 107
                     }
                 },
                 "lengths": {
@@ -1315,9 +1289,7 @@
                     "overlap": 559
                 }
             ],
-            "eclipsed_reaches": [
-                "11906438"
-            ]
+            "eclipsed_reaches": []
         },
         "11905756": {
             "us_xs": {
@@ -1335,9 +1307,10 @@
                 "xs_id": 208205.5
             },
             "eclipsed": false,
-            "low_flow": 284,
-            "high_flow": 1501,
+            "low_flow": 213,
+            "high_flow": 1802,
             "network_to_id": "11906190",
+            "ds_slope": 0.005210000090301037,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1395,9 +1368,10 @@
                 "xs_id": 211665.0
             },
             "eclipsed": false,
-            "low_flow": 140,
-            "high_flow": 1509,
+            "low_flow": 105,
+            "high_flow": 1811,
             "network_to_id": "11905756",
+            "ds_slope": 0.028720000758767128,
             "gage": "01592500",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=01592500&legacy=1",
             "metrics": {
@@ -1457,9 +1431,10 @@
                 "xs_id": 147072.6
             },
             "eclipsed": false,
-            "low_flow": 839,
-            "high_flow": 4564,
+            "low_flow": 629,
+            "high_flow": 5476,
             "network_to_id": "11906000",
+            "ds_slope": 0.000539999979082495,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1503,12 +1478,6 @@
                 "11906000"
             ]
         },
-        "11905974": {
-            "eclipsed": true,
-            "low_flow": 825,
-            "high_flow": 4686,
-            "network_to_id": "11905976"
-        },
         "11905984": {
             "us_xs": {
                 "river": "Patuxent River",
@@ -1525,9 +1494,10 @@
                 "xs_id": 153499.9
             },
             "eclipsed": false,
-            "low_flow": 841,
-            "high_flow": 4702,
+            "low_flow": 630,
+            "high_flow": 5643,
             "network_to_id": "11906290",
+            "ds_slope": 0.0026000000070780516,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1567,9 +1537,7 @@
                     "overlap": 871
                 }
             ],
-            "eclipsed_reaches": [
-                "11905992"
-            ]
+            "eclipsed_reaches": []
         },
         "11906030": {
             "us_xs": {
@@ -1587,9 +1555,10 @@
                 "xs_id": 137262.7
             },
             "eclipsed": false,
-            "low_flow": 835,
-            "high_flow": 4530,
+            "low_flow": 626,
+            "high_flow": 5436,
             "network_to_id": "11906034",
+            "ds_slope": 0.0002699999895412475,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1629,11 +1598,7 @@
                     "overlap": 58
                 }
             ],
-            "eclipsed_reaches": [
-                "11906306",
-                "11906026",
-                "11906310"
-            ]
+            "eclipsed_reaches": []
         },
         "11906036": {
             "us_xs": {
@@ -1651,9 +1616,10 @@
                 "xs_id": 134652.2
             },
             "eclipsed": false,
-            "low_flow": 861,
-            "high_flow": 4603,
+            "low_flow": 646,
+            "high_flow": 5523,
             "network_to_id": "11906038",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1713,9 +1679,10 @@
                 "xs_id": 173461.9
             },
             "eclipsed": false,
-            "low_flow": 851,
-            "high_flow": 4986,
+            "low_flow": 638,
+            "high_flow": 5983,
             "network_to_id": "11906240",
+            "ds_slope": 0.0019600000232458115,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1755,9 +1722,7 @@
                     "overlap": 630
                 }
             ],
-            "eclipsed_reaches": [
-                "11905862"
-            ]
+            "eclipsed_reaches": []
         },
         "11905976": {
             "us_xs": {
@@ -1775,9 +1740,10 @@
                 "xs_id": 155014.3
             },
             "eclipsed": false,
-            "low_flow": 831,
-            "high_flow": 4626,
+            "low_flow": 623,
+            "high_flow": 5551,
             "network_to_id": "11905984",
+            "ds_slope": 0.002050000010058284,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1835,9 +1801,10 @@
                 "xs_id": 131156.0
             },
             "eclipsed": false,
-            "low_flow": 925,
-            "high_flow": 5350,
+            "low_flow": 694,
+            "high_flow": 6420,
             "network_to_id": "11906328",
+            "ds_slope": 0.0014900000533089042,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1895,9 +1862,10 @@
                 "xs_id": 132261.7
             },
             "eclipsed": false,
-            "low_flow": 916,
-            "high_flow": 5085,
+            "low_flow": 687,
+            "high_flow": 6102,
             "network_to_id": "11906048",
+            "ds_slope": 0.002859999891370535,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1937,16 +1905,7 @@
                     "overlap": 285
                 }
             ],
-            "eclipsed_reaches": [
-                "11906042",
-                "11906044"
-            ]
-        },
-        "11906038": {
-            "eclipsed": true,
-            "low_flow": 863,
-            "high_flow": 4597,
-            "network_to_id": "11906046"
+            "eclipsed_reaches": []
         },
         "11906304": {
             "us_xs": {
@@ -1964,9 +1923,10 @@
                 "xs_id": 140356.0
             },
             "eclipsed": false,
-            "low_flow": 838,
-            "high_flow": 4597,
+            "low_flow": 628,
+            "high_flow": 5516,
             "network_to_id": "11906030",
+            "ds_slope": 0.0016199999954551458,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2024,9 +1984,10 @@
                 "xs_id": 149785.6
             },
             "eclipsed": false,
-            "low_flow": 837,
-            "high_flow": 4647,
+            "low_flow": 628,
+            "high_flow": 5576,
             "network_to_id": "11905990",
+            "ds_slope": 0.0008500000112690032,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2066,10 +2027,7 @@
                     "overlap": 207
                 }
             ],
-            "eclipsed_reaches": [
-                "11906006",
-                "11905998"
-            ]
+            "eclipsed_reaches": []
         },
         "11906282": {
             "us_xs": {
@@ -2087,9 +2045,10 @@
                 "xs_id": 156362.6
             },
             "eclipsed": false,
-            "low_flow": 826,
-            "high_flow": 4759,
+            "low_flow": 619,
+            "high_flow": 5711,
             "network_to_id": "11905974",
+            "ds_slope": 0.001180000021122396,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2104,13 +2063,13 @@
                     },
                     "thalweg_offset": {
                         "count": 5,
-                        "mean": 62,
-                        "std": 119,
+                        "mean": 7,
+                        "std": 5,
                         "min": 2,
-                        "25%": 9,
-                        "50%": 10,
-                        "75%": 14,
-                        "max": 275
+                        "25%": 2,
+                        "50%": 9,
+                        "75%": 10,
+                        "max": 14
                     }
                 },
                 "lengths": {
@@ -2149,9 +2108,10 @@
                 "xs_id": 168859.9
             },
             "eclipsed": false,
-            "low_flow": 844,
-            "high_flow": 4928,
+            "low_flow": 633,
+            "high_flow": 5914,
             "network_to_id": "11905886",
+            "ds_slope": 0.0003600000054575503,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2192,8 +2152,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "11905886",
-                "11905880"
+                "11905886"
             ]
         },
         "11908588": {
@@ -2212,9 +2171,10 @@
                 "xs_id": 21021.22
             },
             "eclipsed": false,
-            "low_flow": 2030,
-            "high_flow": 19073,
+            "low_flow": 1523,
+            "high_flow": 22888,
             "network_to_id": "11908594",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2251,12 +2211,6 @@
             "overlapped_reaches": [],
             "eclipsed_reaches": []
         },
-        "11908578": {
-            "eclipsed": true,
-            "low_flow": 2023,
-            "high_flow": 20836,
-            "network_to_id": "11908582"
-        },
         "11908576": {
             "us_xs": {
                 "river": "Patuxent River",
@@ -2273,9 +2227,10 @@
                 "xs_id": 32805.59
             },
             "eclipsed": false,
-            "low_flow": 2018,
-            "high_flow": 20822,
+            "low_flow": 1513,
+            "high_flow": 24987,
             "network_to_id": "11908578",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2316,9 +2271,7 @@
                 }
             ],
             "eclipsed_reaches": [
-                "11908580",
-                "11908578",
-                "11908574"
+                "11908578"
             ]
         },
         "11908572": {
@@ -2337,9 +2290,10 @@
                 "xs_id": 39893.46
             },
             "eclipsed": false,
-            "low_flow": 2032,
-            "high_flow": 21336,
+            "low_flow": 1524,
+            "high_flow": 25603,
             "network_to_id": "11908576",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2379,9 +2333,7 @@
                     "overlap": 297
                 }
             ],
-            "eclipsed_reaches": [
-                "11908570"
-            ]
+            "eclipsed_reaches": []
         },
         "11908562": {
             "us_xs": {
@@ -2399,9 +2351,10 @@
                 "xs_id": 42465.83
             },
             "eclipsed": false,
-            "low_flow": 2032,
-            "high_flow": 21368,
+            "low_flow": 1524,
+            "high_flow": 25642,
             "network_to_id": "11908566",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2441,9 +2394,7 @@
                     "overlap": 404
                 }
             ],
-            "eclipsed_reaches": [
-                "11908564"
-            ]
+            "eclipsed_reaches": []
         },
         "11908566": {
             "us_xs": {
@@ -2461,9 +2412,10 @@
                 "xs_id": 41827.22
             },
             "eclipsed": false,
-            "low_flow": 2033,
-            "high_flow": 21395,
+            "low_flow": 1525,
+            "high_flow": 25674,
             "network_to_id": "11908572",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2503,9 +2455,7 @@
                     "overlap": 474
                 }
             ],
-            "eclipsed_reaches": [
-                "11908568"
-            ]
+            "eclipsed_reaches": []
         },
         "11907892": {
             "us_xs": {
@@ -2523,9 +2473,10 @@
                 "xs_id": 49806.06
             },
             "eclipsed": false,
-            "low_flow": 2031,
-            "high_flow": 21512,
+            "low_flow": 1523,
+            "high_flow": 25815,
             "network_to_id": "11908554",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2583,9 +2534,10 @@
                 "xs_id": 45507.47
             },
             "eclipsed": false,
-            "low_flow": 2024,
-            "high_flow": 21267,
+            "low_flow": 1518,
+            "high_flow": 25520,
             "network_to_id": "11908560",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2625,9 +2577,7 @@
                     "overlap": 1020
                 }
             ],
-            "eclipsed_reaches": [
-                "11908556"
-            ]
+            "eclipsed_reaches": []
         },
         "11908560": {
             "us_xs": {
@@ -2645,9 +2595,10 @@
                 "xs_id": 44258.6
             },
             "eclipsed": false,
-            "low_flow": 2025,
-            "high_flow": 21095,
+            "low_flow": 1518,
+            "high_flow": 25315,
             "network_to_id": "11908562",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2687,9 +2638,7 @@
                     "overlap": 730
                 }
             ],
-            "eclipsed_reaches": [
-                "11908558"
-            ]
+            "eclipsed_reaches": []
         },
         "11907880": {
             "us_xs": {
@@ -2707,9 +2656,10 @@
                 "xs_id": 51040.86
             },
             "eclipsed": false,
-            "low_flow": 2015,
-            "high_flow": 20649,
+            "low_flow": 1511,
+            "high_flow": 24779,
             "network_to_id": "11907892",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2767,9 +2717,10 @@
                 "xs_id": 59049.43
             },
             "eclipsed": false,
-            "low_flow": 2031,
-            "high_flow": 22720,
+            "low_flow": 1523,
+            "high_flow": 27264,
             "network_to_id": "11907880",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2827,9 +2778,10 @@
                 "xs_id": 59680.21
             },
             "eclipsed": false,
-            "low_flow": 2017,
-            "high_flow": 22677,
+            "low_flow": 1513,
+            "high_flow": 27213,
             "network_to_id": "11907860",
+            "ds_slope": 0.0048699998296797276,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2887,9 +2839,10 @@
                 "xs_id": 60994.13
             },
             "eclipsed": false,
-            "low_flow": 2018,
-            "high_flow": 22600,
+            "low_flow": 1513,
+            "high_flow": 27120,
             "network_to_id": "11907854",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2947,9 +2900,10 @@
                 "xs_id": 63352.65
             },
             "eclipsed": false,
-            "low_flow": 1980,
-            "high_flow": 22834,
+            "low_flow": 1485,
+            "high_flow": 27400,
             "network_to_id": "11907848",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3007,9 +2961,10 @@
                 "xs_id": 64024.26
             },
             "eclipsed": false,
-            "low_flow": 1965,
-            "high_flow": 22816,
+            "low_flow": 1474,
+            "high_flow": 27379,
             "network_to_id": "11907838",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3067,9 +3022,10 @@
                 "xs_id": 69955.36
             },
             "eclipsed": false,
-            "low_flow": 2023,
-            "high_flow": 24523,
+            "low_flow": 1517,
+            "high_flow": 29428,
             "network_to_id": "11907832",
+            "ds_slope": 0.00033999999868683517,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3127,9 +3083,10 @@
                 "xs_id": 79897.28
             },
             "eclipsed": false,
-            "low_flow": 2057,
-            "high_flow": 25101,
+            "low_flow": 1543,
+            "high_flow": 30121,
             "network_to_id": "11907806",
+            "ds_slope": 0.0005000000237487257,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3171,12 +3128,6 @@
             ],
             "eclipsed_reaches": []
         },
-        "11907774": {
-            "eclipsed": true,
-            "low_flow": 2036,
-            "high_flow": 25139,
-            "network_to_id": "11907782"
-        },
         "11908324": {
             "us_xs": {
                 "river": "Patuxent River",
@@ -3193,9 +3144,10 @@
                 "xs_id": 86341.97
             },
             "eclipsed": false,
-            "low_flow": 2023,
-            "high_flow": 24922,
+            "low_flow": 1517,
+            "high_flow": 29907,
             "network_to_id": "11907774",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3255,9 +3207,10 @@
                 "xs_id": 92395.85
             },
             "eclipsed": false,
-            "low_flow": 2042,
-            "high_flow": 25872,
+            "low_flow": 1531,
+            "high_flow": 31046,
             "network_to_id": "11908324",
+            "ds_slope": 9.999999747378752e-06,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3299,12 +3252,6 @@
             ],
             "eclipsed_reaches": []
         },
-        "11907764": {
-            "eclipsed": true,
-            "low_flow": 2093,
-            "high_flow": 28222,
-            "network_to_id": "11908316"
-        },
         "11907762": {
             "us_xs": {
                 "river": "Patuxent River",
@@ -3321,9 +3268,10 @@
                 "xs_id": 97274.14
             },
             "eclipsed": false,
-            "low_flow": 2084,
-            "high_flow": 29199,
+            "low_flow": 1563,
+            "high_flow": 35039,
             "network_to_id": "11907764",
+            "ds_slope": 0.00011000000085914508,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3383,9 +3331,10 @@
                 "xs_id": 101166.3
             },
             "eclipsed": false,
-            "low_flow": 2082,
-            "high_flow": 30112,
+            "low_flow": 1562,
+            "high_flow": 36135,
             "network_to_id": "11907762",
+            "ds_slope": 0.0001500000071246177,
             "gage": "01594440",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=01594440&legacy=1",
             "metrics": {
@@ -3445,9 +3394,10 @@
                 "xs_id": 106061.7
             },
             "eclipsed": false,
-            "low_flow": 2087,
-            "high_flow": 30505,
+            "low_flow": 1565,
+            "high_flow": 36606,
             "network_to_id": "11907758",
+            "ds_slope": 0.0008299999753944576,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3505,9 +3455,10 @@
                 "xs_id": 110321.2
             },
             "eclipsed": false,
-            "low_flow": 2084,
-            "high_flow": 31491,
+            "low_flow": 1563,
+            "high_flow": 37789,
             "network_to_id": "11907746",
+            "ds_slope": 0.00023999999393709004,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3565,9 +3516,10 @@
                 "xs_id": 113857.7
             },
             "eclipsed": false,
-            "low_flow": 2081,
-            "high_flow": 31142,
+            "low_flow": 1560,
+            "high_flow": 37371,
             "network_to_id": "11908300",
+            "ds_slope": 0.0009200000204145908,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3625,9 +3577,10 @@
                 "xs_id": 117158.6
             },
             "eclipsed": false,
-            "low_flow": 2082,
-            "high_flow": 30793,
+            "low_flow": 1562,
+            "high_flow": 36952,
             "network_to_id": "11908298",
+            "ds_slope": 0.000539999979082495,
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3668,21 +3621,91 @@
                 }
             ],
             "eclipsed_reaches": []
+        },
+        "11906060": {
+            "eclipsed": true,
+            "low_flow": 698,
+            "high_flow": 6438,
+            "network_to_id": "11907726",
+            "ds_slope": 0.001069999998435378
+        },
+        "11905848": {
+            "eclipsed": true,
+            "low_flow": 624,
+            "high_flow": 5777,
+            "network_to_id": "11906232",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "11905836": {
+            "eclipsed": true,
+            "low_flow": 627,
+            "high_flow": 5758,
+            "network_to_id": "11905844",
+            "ds_slope": 0.0010999999940395355
+        },
+        "11906000": {
+            "eclipsed": true,
+            "low_flow": 628,
+            "high_flow": 5463,
+            "network_to_id": "11906304",
+            "ds_slope": 0.004240000154823065
+        },
+        "11906038": {
+            "eclipsed": true,
+            "low_flow": 647,
+            "high_flow": 5517,
+            "network_to_id": "11906046",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "11905974": {
+            "eclipsed": true,
+            "low_flow": 619,
+            "high_flow": 5624,
+            "network_to_id": "11905976",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "11905886": {
+            "eclipsed": true,
+            "low_flow": 634,
+            "high_flow": 5945,
+            "network_to_id": "11905914",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "11908578": {
+            "eclipsed": true,
+            "low_flow": 1517,
+            "high_flow": 25003,
+            "network_to_id": "11908582",
+            "ds_slope": 9.999999747378752e-06
+        },
+        "11907774": {
+            "eclipsed": true,
+            "low_flow": 1527,
+            "high_flow": 30167,
+            "network_to_id": "11907782",
+            "ds_slope": 0.002139999996870756
+        },
+        "11907764": {
+            "eclipsed": true,
+            "low_flow": 1569,
+            "high_flow": 33867,
+            "network_to_id": "11908316",
+            "ds_slope": 9.999999747378752e-06
         }
     },
     "metadata": {
         "source_network": {
             "file_name": "flows.parquet",
-            "version": "2.1",
-            "type": "nwm_hydrofabric"
+            "type": "nwm_hydrofabric",
+            "version": "2.1"
         },
-        "conflation_png": "PatuxentRiver.conflation.png",
-        "conflation_ripple1d_version": "0.4.2",
-        "metrics_ripple1d_version": "0.4.2",
+        "conflation_ripple1d_version": "0.10.4",
+        "metrics_ripple1d_version": "0.10.4",
         "source_ras_model": {
             "stac_api": "https://stac2.dewberryanalytics.com",
             "stac_collection_id": "ebfe-12090301_LowerColoradoCummins",
             "stac_item_id": "137a9667-e5cf-4cea-b6ec-2e882a42fdc8",
+            "units": "English",
             "source_ras_files": {
                 "geometry": "PatuxentRiver.g01",
                 "forcing": "PatuxentRiver.f01",

--- a/tests/ras-data/PatuxentRiver/PatuxentRiver.conflation.json
+++ b/tests/ras-data/PatuxentRiver/PatuxentRiver.conflation.json
@@ -20,6 +20,7 @@
             "high_flow": 23963,
             "network_to_id": "11908588",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908588",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -80,7 +81,8 @@
             "low_flow": 737,
             "high_flow": 7938,
             "network_to_id": "11908292",
-            "ds_slope": 0.0008900000248104334,
+            "ds_slope": 0.000539999979082495,
+            "ds_slope_source_nwm_id": "11908292",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -141,7 +143,8 @@
             "low_flow": 720,
             "high_flow": 6741,
             "network_to_id": "11907736",
-            "ds_slope": 0.0007800000021234155,
+            "ds_slope": 0.0008900000248104334,
+            "ds_slope_source_nwm_id": "11907736",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -202,7 +205,8 @@
             "low_flow": 697,
             "high_flow": 6604,
             "network_to_id": "11906060",
-            "ds_slope": 0.0009599999757483602,
+            "ds_slope": 0.0007800000021234155,
+            "ds_slope_source_nwm_id": "11907726",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -265,7 +269,8 @@
             "low_flow": 647,
             "high_flow": 5567,
             "network_to_id": "11906036",
-            "ds_slope": 0.0007300000288523734,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11906036",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -326,7 +331,8 @@
             "low_flow": 630,
             "high_flow": 5550,
             "network_to_id": "11905994",
-            "ds_slope": 0.0007399999885819852,
+            "ds_slope": 0.000539999979082495,
+            "ds_slope_source_nwm_id": "11905994",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -387,7 +393,8 @@
             "low_flow": 627,
             "high_flow": 5777,
             "network_to_id": "11906282",
-            "ds_slope": 0.0022700000554323196,
+            "ds_slope": 0.001180000021122396,
+            "ds_slope_source_nwm_id": "11906282",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -448,7 +455,8 @@
             "low_flow": 626,
             "high_flow": 5748,
             "network_to_id": "11906276",
-            "ds_slope": 0.0038799999747425318,
+            "ds_slope": 0.0022700000554323196,
+            "ds_slope_source_nwm_id": "11906276",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -509,7 +517,8 @@
             "low_flow": 624,
             "high_flow": 5729,
             "network_to_id": "11905958",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0038799999747425318,
+            "ds_slope_source_nwm_id": "11905958",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -570,7 +579,8 @@
             "low_flow": 630,
             "high_flow": 5881,
             "network_to_id": "11906270",
-            "ds_slope": 0.003869999898597598,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11906270",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -631,7 +641,8 @@
             "low_flow": 632,
             "high_flow": 5903,
             "network_to_id": "11905918",
-            "ds_slope": 0.0008900000248104334,
+            "ds_slope": 0.003869999898597598,
+            "ds_slope_source_nwm_id": "11905918",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -692,7 +703,8 @@
             "low_flow": 625,
             "high_flow": 5823,
             "network_to_id": "11905848",
-            "ds_slope": 0.0010100000072270632,
+            "ds_slope": 0.0019600000232458115,
+            "ds_slope_source_nwm_id": "11906232",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -755,7 +767,8 @@
             "low_flow": 626,
             "high_flow": 5775,
             "network_to_id": "11905836",
-            "ds_slope": 0.0012100000167265534,
+            "ds_slope": 0.0010100000072270632,
+            "ds_slope_source_nwm_id": "11905844",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -818,7 +831,8 @@
             "low_flow": 627,
             "high_flow": 5899,
             "network_to_id": "11905838",
-            "ds_slope": 0.00022000000171829015,
+            "ds_slope": 0.0012100000167265534,
+            "ds_slope_source_nwm_id": "11905838",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -879,7 +893,8 @@
             "low_flow": 627,
             "high_flow": 5742,
             "network_to_id": "11906208",
-            "ds_slope": 0.0017600000137463212,
+            "ds_slope": 0.00022000000171829015,
+            "ds_slope_source_nwm_id": "11906208",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -940,7 +955,8 @@
             "low_flow": 607,
             "high_flow": 5289,
             "network_to_id": "11905834",
-            "ds_slope": 0.0002500000118743628,
+            "ds_slope": 0.00022000000171829015,
+            "ds_slope_source_nwm_id": "11906208",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1005,7 +1021,8 @@
             "low_flow": 585,
             "high_flow": 4501,
             "network_to_id": "11905828",
-            "ds_slope": 0.0016599999507889152,
+            "ds_slope": 0.0002500000118743628,
+            "ds_slope_source_nwm_id": "11905828",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1066,7 +1083,8 @@
             "low_flow": 312,
             "high_flow": 2506,
             "network_to_id": "11905820",
-            "ds_slope": 0.0023399998899549246,
+            "ds_slope": 0.0016599999507889152,
+            "ds_slope_source_nwm_id": "11905820",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1127,7 +1145,8 @@
             "low_flow": 304,
             "high_flow": 2554,
             "network_to_id": "11906198",
-            "ds_slope": 0.001769999973475933,
+            "ds_slope": 0.0023399998899549246,
+            "ds_slope_source_nwm_id": "11906198",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1188,7 +1207,8 @@
             "low_flow": 300,
             "high_flow": 2812,
             "network_to_id": "11906196",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.001769999973475933,
+            "ds_slope_source_nwm_id": "11906196",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1249,7 +1269,8 @@
             "low_flow": 321,
             "high_flow": 3082,
             "network_to_id": "11905796",
-            "ds_slope": 0.0012000000569969416,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11905796",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1310,7 +1331,8 @@
             "low_flow": 213,
             "high_flow": 1802,
             "network_to_id": "11906190",
-            "ds_slope": 0.005210000090301037,
+            "ds_slope": 0.0012000000569969416,
+            "ds_slope_source_nwm_id": "11906190",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1371,9 +1393,10 @@
             "low_flow": 105,
             "high_flow": 1811,
             "network_to_id": "11905756",
-            "ds_slope": 0.028720000758767128,
             "gage": "01592500",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=01592500&legacy=1",
+            "ds_slope": 0.005210000090301037,
+            "ds_slope_source_nwm_id": "11905756",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1434,7 +1457,8 @@
             "low_flow": 629,
             "high_flow": 5476,
             "network_to_id": "11906000",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 0.0016199999954551458,
+            "ds_slope_source_nwm_id": "11906304",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1497,7 +1521,8 @@
             "low_flow": 630,
             "high_flow": 5643,
             "network_to_id": "11906290",
-            "ds_slope": 0.0026000000070780516,
+            "ds_slope": 0.0008500000112690032,
+            "ds_slope_source_nwm_id": "11906290",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1558,7 +1583,8 @@
             "low_flow": 626,
             "high_flow": 5436,
             "network_to_id": "11906034",
-            "ds_slope": 0.0002699999895412475,
+            "ds_slope": 0.0007300000288523734,
+            "ds_slope_source_nwm_id": "11906034",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1619,7 +1645,8 @@
             "low_flow": 646,
             "high_flow": 5523,
             "network_to_id": "11906038",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.002859999891370535,
+            "ds_slope_source_nwm_id": "11906046",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1682,7 +1709,8 @@
             "low_flow": 638,
             "high_flow": 5983,
             "network_to_id": "11906240",
-            "ds_slope": 0.0019600000232458115,
+            "ds_slope": 0.0003600000054575503,
+            "ds_slope_source_nwm_id": "11906240",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1743,7 +1771,8 @@
             "low_flow": 623,
             "high_flow": 5551,
             "network_to_id": "11905984",
-            "ds_slope": 0.002050000010058284,
+            "ds_slope": 0.0026000000070780516,
+            "ds_slope_source_nwm_id": "11905984",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1804,7 +1833,8 @@
             "low_flow": 694,
             "high_flow": 6420,
             "network_to_id": "11906328",
-            "ds_slope": 0.0014900000533089042,
+            "ds_slope": 0.0009599999757483602,
+            "ds_slope_source_nwm_id": "11906328",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1865,7 +1895,8 @@
             "low_flow": 687,
             "high_flow": 6102,
             "network_to_id": "11906048",
-            "ds_slope": 0.002859999891370535,
+            "ds_slope": 0.0014900000533089042,
+            "ds_slope_source_nwm_id": "11906048",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1926,7 +1957,8 @@
             "low_flow": 628,
             "high_flow": 5516,
             "network_to_id": "11906030",
-            "ds_slope": 0.0016199999954551458,
+            "ds_slope": 0.0002699999895412475,
+            "ds_slope_source_nwm_id": "11906030",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -1987,7 +2019,8 @@
             "low_flow": 628,
             "high_flow": 5576,
             "network_to_id": "11905990",
-            "ds_slope": 0.0008500000112690032,
+            "ds_slope": 0.0007399999885819852,
+            "ds_slope_source_nwm_id": "11905990",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2048,7 +2081,8 @@
             "low_flow": 619,
             "high_flow": 5711,
             "network_to_id": "11905974",
-            "ds_slope": 0.001180000021122396,
+            "ds_slope": 0.002050000010058284,
+            "ds_slope_source_nwm_id": "11905976",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2111,7 +2145,8 @@
             "low_flow": 633,
             "high_flow": 5914,
             "network_to_id": "11905886",
-            "ds_slope": 0.0003600000054575503,
+            "ds_slope": 0.0008900000248104334,
+            "ds_slope_source_nwm_id": "11905914",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2175,6 +2210,7 @@
             "high_flow": 22888,
             "network_to_id": "11908594",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908588",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2231,6 +2267,7 @@
             "high_flow": 24987,
             "network_to_id": "11908578",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908582",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2294,6 +2331,7 @@
             "high_flow": 25603,
             "network_to_id": "11908576",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908576",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2355,6 +2393,7 @@
             "high_flow": 25642,
             "network_to_id": "11908566",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908566",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2416,6 +2455,7 @@
             "high_flow": 25674,
             "network_to_id": "11908572",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908572",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2477,6 +2517,7 @@
             "high_flow": 25815,
             "network_to_id": "11908554",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908554",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2538,6 +2579,7 @@
             "high_flow": 25520,
             "network_to_id": "11908560",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908560",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2599,6 +2641,7 @@
             "high_flow": 25315,
             "network_to_id": "11908562",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908562",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2660,6 +2703,7 @@
             "high_flow": 24779,
             "network_to_id": "11907892",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11907892",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2721,6 +2765,7 @@
             "high_flow": 27264,
             "network_to_id": "11907880",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11907880",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2781,7 +2826,8 @@
             "low_flow": 1513,
             "high_flow": 27213,
             "network_to_id": "11907860",
-            "ds_slope": 0.0048699998296797276,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11907860",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2842,7 +2888,8 @@
             "low_flow": 1513,
             "high_flow": 27120,
             "network_to_id": "11907854",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0048699998296797276,
+            "ds_slope_source_nwm_id": "11907854",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2904,6 +2951,7 @@
             "high_flow": 27400,
             "network_to_id": "11907848",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11907848",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -2965,6 +3013,7 @@
             "high_flow": 27379,
             "network_to_id": "11907838",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11907838",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3025,7 +3074,8 @@
             "low_flow": 1517,
             "high_flow": 29428,
             "network_to_id": "11907832",
-            "ds_slope": 0.00033999999868683517,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11907832",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3086,7 +3136,8 @@
             "low_flow": 1543,
             "high_flow": 30121,
             "network_to_id": "11907806",
-            "ds_slope": 0.0005000000237487257,
+            "ds_slope": 0.00033999999868683517,
+            "ds_slope_source_nwm_id": "11907806",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3147,7 +3198,8 @@
             "low_flow": 1517,
             "high_flow": 29907,
             "network_to_id": "11907774",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.0005000000237487257,
+            "ds_slope_source_nwm_id": "11907782",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3211,6 +3263,7 @@
             "high_flow": 31046,
             "network_to_id": "11908324",
             "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908324",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3271,7 +3324,8 @@
             "low_flow": 1563,
             "high_flow": 35039,
             "network_to_id": "11907764",
-            "ds_slope": 0.00011000000085914508,
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "11908316",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3334,9 +3388,10 @@
             "low_flow": 1562,
             "high_flow": 36135,
             "network_to_id": "11907762",
-            "ds_slope": 0.0001500000071246177,
             "gage": "01594440",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=01594440&legacy=1",
+            "ds_slope": 0.00011000000085914508,
+            "ds_slope_source_nwm_id": "11907762",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3397,7 +3452,8 @@
             "low_flow": 1565,
             "high_flow": 36606,
             "network_to_id": "11907758",
-            "ds_slope": 0.0008299999753944576,
+            "ds_slope": 0.0001500000071246177,
+            "ds_slope_source_nwm_id": "11907758",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3458,7 +3514,8 @@
             "low_flow": 1563,
             "high_flow": 37789,
             "network_to_id": "11907746",
-            "ds_slope": 0.00023999999393709004,
+            "ds_slope": 0.0008299999753944576,
+            "ds_slope_source_nwm_id": "11907746",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3519,7 +3576,8 @@
             "low_flow": 1560,
             "high_flow": 37371,
             "network_to_id": "11908300",
-            "ds_slope": 0.0009200000204145908,
+            "ds_slope": 0.00023999999393709004,
+            "ds_slope_source_nwm_id": "11908300",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3580,7 +3638,8 @@
             "low_flow": 1562,
             "high_flow": 36952,
             "network_to_id": "11908298",
-            "ds_slope": 0.000539999979082495,
+            "ds_slope": 0.0009200000204145908,
+            "ds_slope_source_nwm_id": "11908298",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -3626,71 +3685,61 @@
             "eclipsed": true,
             "low_flow": 698,
             "high_flow": 6438,
-            "network_to_id": "11907726",
-            "ds_slope": 0.001069999998435378
+            "network_to_id": "11907726"
         },
         "11905848": {
             "eclipsed": true,
             "low_flow": 624,
             "high_flow": 5777,
-            "network_to_id": "11906232",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "11906232"
         },
         "11905836": {
             "eclipsed": true,
             "low_flow": 627,
             "high_flow": 5758,
-            "network_to_id": "11905844",
-            "ds_slope": 0.0010999999940395355
+            "network_to_id": "11905844"
         },
         "11906000": {
             "eclipsed": true,
             "low_flow": 628,
             "high_flow": 5463,
-            "network_to_id": "11906304",
-            "ds_slope": 0.004240000154823065
+            "network_to_id": "11906304"
         },
         "11906038": {
             "eclipsed": true,
             "low_flow": 647,
             "high_flow": 5517,
-            "network_to_id": "11906046",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "11906046"
         },
         "11905974": {
             "eclipsed": true,
             "low_flow": 619,
             "high_flow": 5624,
-            "network_to_id": "11905976",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "11905976"
         },
         "11905886": {
             "eclipsed": true,
             "low_flow": 634,
             "high_flow": 5945,
-            "network_to_id": "11905914",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "11905914"
         },
         "11908578": {
             "eclipsed": true,
             "low_flow": 1517,
             "high_flow": 25003,
-            "network_to_id": "11908582",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "11908582"
         },
         "11907774": {
             "eclipsed": true,
             "low_flow": 1527,
             "high_flow": 30167,
-            "network_to_id": "11907782",
-            "ds_slope": 0.002139999996870756
+            "network_to_id": "11907782"
         },
         "11907764": {
             "eclipsed": true,
             "low_flow": 1569,
             "high_flow": 33867,
-            "network_to_id": "11908316",
-            "ds_slope": 9.999999747378752e-06
+            "network_to_id": "11908316"
         }
     },
     "metadata": {

--- a/tests/ras-data/winooski/winooski.conflation.json
+++ b/tests/ras-data/winooski/winooski.conflation.json
@@ -19,7 +19,7 @@
             "low_flow": 0,
             "high_flow": 51397,
             "network_to_id": "4576960",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 0.00013,
             "ds_slope_source_nwm_id": "4576956",
             "metrics": {
                 "xs": {
@@ -78,7 +78,7 @@
             "network_to_id": "4576958",
             "gage": "04290560",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=04290560&legacy=1",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 1e-05,
             "ds_slope_source_nwm_id": "4576958",
             "metrics": {
                 "xs": {
@@ -140,7 +140,7 @@
             "low_flow": 0,
             "high_flow": 52528,
             "network_to_id": "4576956",
-            "ds_slope": 0.00013000000035390258,
+            "ds_slope": 0.00013,
             "ds_slope_source_nwm_id": "4576956",
             "metrics": {
                 "xs": {

--- a/tests/ras-data/winooski/winooski.conflation.json
+++ b/tests/ras-data/winooski/winooski.conflation.json
@@ -17,9 +17,44 @@
             },
             "eclipsed": false,
             "low_flow": 0,
-            "high_flow": 42831,
+            "high_flow": 51397,
             "network_to_id": "4576960",
-            "metrics": {}
+            "ds_slope": 0.00013000000035390258,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 29,
+                        "std": 24,
+                        "min": 7,
+                        "25%": 10,
+                        "50%": 23,
+                        "75%": 48,
+                        "max": 62
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 136,
+                        "std": 142,
+                        "min": 0,
+                        "25%": 9,
+                        "50%": 134,
+                        "75%": 264,
+                        "max": 275
+                    }
+                },
+                "lengths": {
+                    "ras": 18487,
+                    "network": 18074,
+                    "network_to_ras_ratio": 0.98
+                },
+                "coverage": {
+                    "start": 0.01,
+                    "end": 0.45
+                }
+            },
+            "overlapped_reaches": [],
+            "eclipsed_reaches": []
         },
         "4578832": {
             "us_xs": {
@@ -38,11 +73,51 @@
             },
             "eclipsed": false,
             "low_flow": 0,
-            "high_flow": 43789,
+            "high_flow": 52547,
             "network_to_id": "4576958",
+            "ds_slope": 0.004000000189989805,
             "gage": "04290560",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=04290560&legacy=1",
-            "metrics": {}
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 6,
+                        "mean": 22,
+                        "std": 14,
+                        "min": 11,
+                        "25%": 15,
+                        "50%": 18,
+                        "75%": 24,
+                        "max": 49
+                    },
+                    "thalweg_offset": {
+                        "count": 6,
+                        "mean": 129,
+                        "std": 131,
+                        "min": 11,
+                        "25%": 23,
+                        "50%": 85,
+                        "75%": 231,
+                        "max": 310
+                    }
+                },
+                "lengths": {
+                    "ras": 7296,
+                    "network": 7335,
+                    "network_to_ras_ratio": 1.01
+                },
+                "coverage": {
+                    "start": 0.69,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "4576958",
+                    "overlap": 743
+                }
+            ],
+            "eclipsed_reaches": []
         },
         "4576958": {
             "us_xs": {
@@ -61,29 +136,72 @@
             },
             "eclipsed": false,
             "low_flow": 0,
-            "high_flow": 43773,
+            "high_flow": 52528,
             "network_to_id": "4576956",
-            "metrics": {}
+            "ds_slope": 9.999999747378752e-06,
+            "metrics": {
+                "xs": {
+                    "centerline_offset": {
+                        "count": 5,
+                        "mean": 20,
+                        "std": 14,
+                        "min": 7,
+                        "25%": 11,
+                        "50%": 11,
+                        "75%": 35,
+                        "max": 35
+                    },
+                    "thalweg_offset": {
+                        "count": 5,
+                        "mean": 200,
+                        "std": 116,
+                        "min": 19,
+                        "25%": 156,
+                        "50%": 251,
+                        "75%": 266,
+                        "max": 310
+                    }
+                },
+                "lengths": {
+                    "ras": 3555,
+                    "network": 3663,
+                    "network_to_ras_ratio": 1.03
+                },
+                "coverage": {
+                    "start": 0.18,
+                    "end": 1
+                }
+            },
+            "overlapped_reaches": [
+                {
+                    "id": "4576956",
+                    "overlap": 368
+                }
+            ],
+            "eclipsed_reaches": []
         }
     },
     "metadata": {
         "source_network": {
             "file_name": "flows.parquet",
-            "version": "2.1",
-            "type": "nwm_hydrofabric"
+            "type": "nwm_hydrofabric",
+            "version": "2.1"
         },
-        "conflation_ripple1d_version": "0.8.1",
-        "metrics_ripple1d_version": "0.8.1",
+        "conflation_ripple1d_version": "0.10.4",
+        "metrics_ripple1d_version": "0.10.4",
         "source_ras_model": {
             "stac_api": "https://stac2.dewberryanalytics.com",
             "stac_collection_id": "ebfe-12090301_LowerColoradoCummins",
             "stac_item_id": "137a9667-e5cf-4cea-b6ec-2e882a42fdc8",
+            "units": "English",
             "source_ras_files": {
                 "geometry": "winooski.g01",
                 "forcing": "winooski.f01",
                 "project-file": "winooski.prj",
                 "plan": "winooski.p01"
             }
-        }
+        },
+        "length_units": "feet",
+        "flow_units": "cfs"
     }
 }

--- a/tests/ras-data/winooski/winooski.conflation.json
+++ b/tests/ras-data/winooski/winooski.conflation.json
@@ -20,6 +20,7 @@
             "high_flow": 51397,
             "network_to_id": "4576960",
             "ds_slope": 0.00013000000035390258,
+            "ds_slope_source_nwm_id": "4576956",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -75,9 +76,10 @@
             "low_flow": 0,
             "high_flow": 52547,
             "network_to_id": "4576958",
-            "ds_slope": 0.004000000189989805,
             "gage": "04290560",
             "gage_url": "https://waterdata.usgs.gov/nwis/uv?site_no=04290560&legacy=1",
+            "ds_slope": 9.999999747378752e-06,
+            "ds_slope_source_nwm_id": "4576958",
             "metrics": {
                 "xs": {
                     "centerline_offset": {
@@ -138,7 +140,8 @@
             "low_flow": 0,
             "high_flow": 52528,
             "network_to_id": "4576956",
-            "ds_slope": 9.999999747378752e-06,
+            "ds_slope": 0.00013000000035390258,
+            "ds_slope_source_nwm_id": "4576956",
             "metrics": {
                 "xs": {
                     "centerline_offset": {


### PR DESCRIPTION
#### Summary
Replace the hardcoded 0.001 downstream normal depth slope with the actual NWM reach slope from the hydrofabric. Discussion in https://github.com/NGWPC/ripple1d-archive/issues/220 confirmed that using the actual slope reduced water surface elevation discrepancies by several feet.

#### Addressing review feedback
- Constant rename: `NORMAL_DEPTH` → `DEFAULT_ND_SLOPE` — the constant stores a slope value, not a boundary condition type.
- Slope source reach: the slope now comes from the NWM reach the submodel's final downstream cross-section actually intersects — not blindly from the current reach. Implemented via spatial intersection + network walk.

#### Changes
- New helpers in `rasfim.py`:
  - `_ds_xs_geometry()` — resolves the ds_xs dict back to its RAS geometry
  - `_select_ds_slope_reach()` — when the ds_xs intersects multiple NWM reaches, walks the `to_id` chain from the current reach and picks the *furthest downstream* candidate
  - `get_ds_boundary_slope()` — orchestrates the full lookup with fallback chain: walk result → current reach slope → `DEFAULT_ND_SLOPE`
- Conflation JSON now includes `ds_slope` and `ds_slope_source_nwm_id` (audit field showing which reach provided the slope)
- `create_model_run_normal_depth()` and `run_incremental_normal_depth()` (`ras_run.py`) pass `ds_slope` to `normal_depth_run()`, falling back to `DEFAULT_ND_SLOPE`
- FAQ (`docs/source/faq.rst`) and docstrings updated

#### Incidental cleanups
While in these files, also:
- Fixed spelling typos (extenstion→extension, Detemine→Determine, junciton→junction, etc.)
- Removed unused imports in `ras.py`, `ras_run.py`, `ras_conflate.py`
- Replaced hardcoded `False` defaults with `SHOW_RAS` constant from `consts.py` for `show_ras` parameter

#### Conflation file changes
- `tests/ras-data/*/{Baxter,MissFldwy,PatuxentRiver,winooski}.conflation.json`: Regenerated against `tests/nwm-data/flows.parquet` to pick up new `ds_slope` and `ds_slope_source_nwm_id` values

#### Testing
- `pytest tests/conflation_test.py -v` — 16 unit tests pass (5 new tests covering the slope selection logic and fallback chain)
- `pytest tests/conflation_tests/conflation_test.py -v` — all 14 integration tests pass