### PR TITLE
Rework KWSE flooring: per-discharge tailwater on an absolute grid

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -60,6 +60,16 @@ Frequently Asked Questions
     The selected slope is clamped to [MIN_ND_SLOPE, MAX_ND_SLOPE] (defined in ripple1d/consts.py)
     to keep the 1D HEC-RAS steady-flow solver numerically stable.
 
+    Subsequent known water surface elevation (KWSE) runs replace the normal depth
+    boundary with a fixed downstream water surface elevation. Each discharge is executed over its own
+    range: from a per-flow floor up to a shared ceiling (``max_elevation``), in
+    ``depth_increment`` steps. The floor comes from ``min_elevation_curve``, a
+    lower-bound curve of ``[discharge, elevation]`` pairs supplied by the caller who should
+    drive it from the downstream reach. For a given discharge, the floor is the
+    elevation of the greatest tabulated discharge less than or equal to that flow;
+    discharges below the lowest tabulated value clamp to the lowest floor, and those
+    above the highest hold the highest floor.
+
 .. dropdown:: Which plan, geometry, and flow files are used?
 
     Source model files are scanned and a "primary" plan file is identified as the

--- a/ripple1d/api/postman_collection.json
+++ b/ripple1d/api/postman_collection.json
@@ -249,7 +249,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"submodel_directory\": \"{{submodels_base_directory}}\\\\{{nwm_reach_id}}\",\r\n    \"plan_suffix\": \"ikwse\",\r\n    \"min_elevation\": 163.0,\r\n    \"max_elevation\": 165.0,\r\n    \"depth_increment\": 1.0,\r\n    \"ras_version\": \"631\",\r\n    \"show_ras\":true,\r\n    \"write_depth_grids\":false\r\n}",
+							"raw": "{\r\n    \"submodel_directory\": \"{{submodels_base_directory}}\\\\{{nwm_reach_id}}\",\r\n    \"plan_suffix\": \"ikwse\",\r\n    \"min_elevation_curve\": [[100, 163.0], [200, 164.0]],\r\n    \"max_elevation\": 165.0,\r\n    \"depth_increment\": 1.0,\r\n    \"ras_version\": \"631\",\r\n    \"show_ras\":true,\r\n    \"write_depth_grids\":false\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/ripple1d/ops/ras_run.py
+++ b/ripple1d/ops/ras_run.py
@@ -12,6 +12,10 @@ from ripple1d.data_model import FlowChangeLocation, NwmReachModel
 from ripple1d.errors import UnitsError
 from ripple1d.ras import RasManager
 
+# Allowed KWSE stage increments (ft). Restricted so that we can be consistent with one-decimal
+# precision, a 0.25 would break one decimal precision rule.
+ALLOWED_DEPTH_INCREMENTS = (0.5, 1, 2, 5, 10)
+
 
 def create_model_run_normal_depth(
     submodel_directory: str,
@@ -224,7 +228,7 @@ def run_incremental_normal_depth(
 def run_known_wse(
     submodel_directory: str,
     plan_suffix: str,
-    min_elevation: float,
+    min_elevation_curve: list,
     max_elevation: float,
     depth_increment=2,
     ras_version: str = "631",
@@ -239,12 +243,13 @@ def run_known_wse(
         The path to the directory containing a sub model geopackage
     plan_suffix : str
         characters to append to the end of the plan name, by default "_kwse"
-    min_elevation : float
-        minimum value for downstream boundary condition
+    min_elevation_curve : list[list[float]]
+        Tailwater min elevation curve as ``[discharge, wse]`` pairs. Each flow's floor
+        elevation is looked up from this curve (see Notes).
     max_elevation : float
-        maximum value for downstream boundary condition
+        Ceiling elevation: the shared upper bound of the downstream boundary
     depth_increment : int, optional
-        depth to increment stages between min and max elevation, by default 2
+        depth to increment stages between the floor and the ceiling, by default 2
     ras_version : str, optional
         which version of HEC-RAS to use, by default "631"
     write_depth_grids : str, optional
@@ -256,23 +261,38 @@ def run_known_wse(
 
     Returns
     -------
-    str
-        string representation of flow file data
+    dict
+        mapping of the kwse plan name to the known water surface elevations used,
+        and the HEC-RAS process id under "pid"
 
     Raises
     ------
     FileNotFoundError
         raised when .conflation.json file not found in submodel_directory
+    ValueError
+        raised when min_elevation_curve or max_elevation is missing
 
     Notes
     -----
-    run_known_wse creates a catalog of stage-discharge rating curves
-    conditioned on downstream water surface elevation. For each depth increment
-    between min_elevation and max_elevation, a unique rating curve is
-    generated. Discharges for the rating curves are selected from the HEC-RAS
-    plan with suffix "_nd" generated with Run_incremental_normal_depth.
+    run_known_wse creates a catalog of stage-discharge rating curves conditioned on
+    downstream water surface elevation. Discharges are selected from the HEC-RAS
+    plan with suffix "_nd" generated with run_incremental_normal_depth. Each
+    discharge is executed over its own range, at depth_increment steps.
+
+    The floor for a discharge is looked up from min_elevation_curve data point:
+    the wse of the greatest tabulated discharge that is lower or equal to the flow.
+    Flows below the lowest tabulated discharge clamp to the lowest floor; flows at
+    or above the highest hold the highest floor.
     """
     logging.info("run_known_wse starting")
+
+    if not min_elevation_curve:
+        raise ValueError("run_known_wse requires a non-empty min_elevation_curve")
+    if max_elevation is None:
+        raise ValueError("run_known_wse requires max_elevation")
+    if depth_increment not in ALLOWED_DEPTH_INCREMENTS:
+        raise ValueError(f"depth_increment must be one of {ALLOWED_DEPTH_INCREMENTS}, got {depth_increment}")
+
     nwm_rm = NwmReachModel(submodel_directory)
 
     if not nwm_rm.file_exists(nwm_rm.conflation_file):
@@ -280,39 +300,33 @@ def run_known_wse(
 
     logging.info(f"Working on known water surface elevation run for nwm_id: {nwm_rm.model_name}")
 
-    start_elevation = np.floor(min_elevation * 2) / 2  # round down to nearest .0 or .5
-    known_water_surface_elevations = np.arange(start_elevation, max_elevation + depth_increment, depth_increment)
-
     # write and compute flow/plans for known water surface elevation runs
     rm = RasManager(nwm_rm.ras_project_file, version=ras_version, terrain_path=nwm_rm.ras_terrain_hdf, crs=nwm_rm.crs)
 
-    # get resulting depths from the second normal depth runs_nd
+    # get the flows from the second normal depth run (_nd), each flow is executed over
+    # its own [floor, ceiling] elevation range
     rm.plan = rm.plans[f"{nwm_rm.model_name}_nd"]
-    ds_flows, ds_depths, _ = get_flow_depth_arrays(
+    ds_xs = rm.geoms[nwm_rm.model_name].rivers[nwm_rm.model_name][nwm_rm.model_name].ds_xs
+    ds_flows, _, _ = get_flow_depth_arrays(
         rm,
         nwm_rm.model_name,
         nwm_rm.model_name,
-        rm.geoms[nwm_rm.model_name].rivers[nwm_rm.model_name][nwm_rm.model_name].ds_xs.river_station_str,
-        rm.geoms[nwm_rm.model_name].rivers[nwm_rm.model_name][nwm_rm.model_name].ds_xs.thalweg,
+        ds_xs.river_station_str,
+        ds_xs.thalweg,
     )
 
-    known_depths = (
-        known_water_surface_elevations
-        - rm.geoms[nwm_rm.model_name].rivers[nwm_rm.model_name][nwm_rm.model_name].ds_xs.thalweg
-    )
-
-    # filter known water surface elevations less than depths resulting from the second normal depth run
-    depths, flows, wses = create_flow_depth_combinations(
-        known_depths,
-        known_water_surface_elevations,
+    depths, flows, wses = create_flow_wse_envelopes(
         ds_flows,
-        ds_depths,
+        min_elevation_curve,
+        max_elevation,
+        depth_increment,
+        ds_xs.thalweg,
     )
 
     if not flows:
         logging.warning(
-            f"No controling known water surface elevations were identified for {nwm_rm.model_name}; i.e., the depth of flooding\
- for the normal depth run for a given flow was alway higher than the known water surface elevations of the downstream reach"
+            f"No known water surface elevations were identified for {nwm_rm.model_name}; "
+            "i.e., every flow's floor elevation was above max_elevation."
         )
         pid = None
     else:
@@ -330,7 +344,7 @@ def run_known_wse(
             run_ras=True,
         )
     logging.info("run_known_wse complete")
-    return {f"{nwm_rm.model_name}_{plan_suffix}": {"kwse": known_water_surface_elevations.tolist()}, "pid": pid}
+    return {f"{nwm_rm.model_name}_{plan_suffix}": {"kwse": sorted(set(wses))}, "pid": pid}
 
 
 def get_flow_depth_arrays(
@@ -382,30 +396,86 @@ def determine_flow_increments(
     return new_flows.astype(int), new_depths, new_wse
 
 
-def create_flow_depth_combinations(
-    ds_depths: list, ds_wses: list, input_flows: np.array, min_depths: pd.Series
-) -> tuple:
-    """
-    Create flow-depth-wse combinations.
+def stepwise_floor_lookup(flow: float, curve: list[list[float]]) -> float:
+    """Return the floor WSE for a flow using previous-value (last-known) lookup.
 
-    Args:
-        ds_depths (list): downstream depths
-        ds_wses (list): downstream water surface elevations
-        input_flows (np.array): Flows to create profiles names from. Combine with incremental depths
-            of the downstream cross section of the reach
-        min_depths (pd.Series): minimum depth to be included. (typically derived from a previous noraml depth run)
+    Parameters
+    ----------
+    flow : float
+        Discharge to look up.
+    curve : list[list[float]]
+        Tailwater lower-bound curve as ``[discharge, wse]`` pairs. The floor is the
+        wse of the greatest tabulated discharge that is <= flow. Flows below the
+        lowest tabulated discharge clamp to the lowest floor; flows at or above the
+        highest discharge hold the highest floor.
 
     Returns
     -------
-        tuple: tuple of depths, flows, and wses
+    float
+        The floor WSE for the flow.
     """
+    sorted_curve = sorted(curve, key=lambda pair: pair[0])
+    floor = sorted_curve[0][1]  # clamp below-range flows to the lowest floor
+    for discharge, wse in sorted_curve:
+        if discharge <= flow:
+            floor = wse
+        else:
+            break
+    return floor
+
+
+def create_flow_wse_envelopes(
+    ds_flows: pd.Series,
+    min_elevation_curve: list,
+    max_elevation: float,
+    depth_increment: float,
+    thalweg: float,
+) -> tuple:
+    """Sweep each flow over its own [floor, ceiling] known-WSE envelope.
+
+    Parameters
+    ----------
+    ds_flows : pd.Series
+        Discharges from the downstream cross section of the normal depth run.
+    min_elevation_curve : list
+        Tailwater lower-bound curve as ``[discharge, wse]`` pairs.
+    max_elevation : float
+        Ceiling elevation shared by every flow.
+    depth_increment : float
+        Elevation step between the floor and the ceiling.
+    thalweg : float
+        Downstream cross-section thalweg, used to convert WSE to depth.
+
+    Returns
+    -------
+    tuple
+        Parallel ``(depths, flows, wses)`` lists, one entry per (flow, wse) profile.
+
+    Notes
+    -----
+    The grid is anchored by 0 (so ``Δz=1`` gives whole feet, ``Δz=0.5`` half feet, ``Δz=2``
+    even feet), and every discharge therefore shares one grid regardless of where its tailwater
+    falls. Both the shared ceiling (``max_elevation``) and each discharge's floor are rounded to
+    the nearest grid line.
+    ``depth_increment`` must be one of ``ALLOWED_DEPTH_INCREMENTS``.
+    """
+    inc = depth_increment
+    if inc not in ALLOWED_DEPTH_INCREMENTS:
+        raise ValueError(f"depth_increment must be one of {ALLOWED_DEPTH_INCREMENTS}, got {inc}")
+
+    def nearest_k(elevation):
+        """Index of the nearest absolute grid line k*inc, rounding halves up."""
+        return int(np.floor(elevation / inc + 0.5))
+
     depths, flows, wses = [], [], []
-    for wse, depth in zip(ds_wses, ds_depths):
-        for profile, flow in input_flows.items():
-            if depth >= min_depths.loc[profile]:
-                depths.append(round(depth, 1))
-                flows.append(int(max([flow, MIN_FLOW])))
-                wses.append(round(wse, 1))
+    ceil_k = nearest_k(max_elevation)  # shared top rung, same for every discharge
+    for flow in ds_flows:
+        floor = stepwise_floor_lookup(flow, min_elevation_curve)
+        for k in range(nearest_k(floor), ceil_k + 1):
+            wse = round(k * inc, 1)
+            depths.append(round(wse - thalweg, 1))
+            flows.append(int(max([flow, MIN_FLOW])))
+            wses.append(wse)
     return (depths, flows, wses)
 
 

--- a/ripple1d/version.py
+++ b/ripple1d/version.py
@@ -1,3 +1,3 @@
 """ripple1d version."""
 
-__version__ = "0.10.4"
+__version__ = "0.11.0"

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -145,7 +145,7 @@ class TestApi(unittest.TestCase):
         payload = {
             "submodel_directory": self.SUBMODELS_DIRECTORY,
             "plan_suffix": "ikwse",
-            "min_elevation": self.min_elevation + 40,
+            "min_elevation_curve": [[0, self.min_elevation + 40]],
             "max_elevation": self.min_elevation + 41,
             "depth_increment": 1.0,
             "ras_version": "631",
@@ -172,7 +172,7 @@ class TestApi(unittest.TestCase):
         payload = {
             "submodel_directory": self.SUBMODELS_DIRECTORY,
             "plan_suffix": "kwse",
-            "min_elevation": self.min_elevation + 40,
+            "min_elevation_curve": [[0, self.min_elevation + 40]],
             "max_elevation": self.min_elevation + 41,
             "depth_increment": 1.0,
             "ras_version": "631",

--- a/tests/rounding_error_test.py
+++ b/tests/rounding_error_test.py
@@ -28,7 +28,7 @@ def test_kwse_run():
         "plan_suffix": "kwse",
         "show_ras": True,
         "write_depth_grids": False,
-        "min_elevation": 182.2,
+        "min_elevation_curve": [[0, 182.2]],
         "max_elevation": 194.1,
         "depth_increment": 1,
     }

--- a/tests/test_flow_wse_envelopes.py
+++ b/tests/test_flow_wse_envelopes.py
@@ -1,0 +1,152 @@
+"""Unit tests for the flow-conditioned known-water-surface-elevation helpers.
+
+These exercise the pure functions in ripple1d.ops.ras_run and do not require
+HEC-RAS.
+"""
+
+import pandas as pd
+import pytest
+
+from ripple1d.consts import MIN_FLOW
+from ripple1d.ops.ras_run import (
+    ALLOWED_DEPTH_INCREMENTS,
+    create_flow_wse_envelopes,
+    stepwise_floor_lookup,
+)
+
+# tailwater lower-bound curve used across the tests: [discharge, wse]
+CURVE = [[100, 20], [200, 24], [256, 26]]
+
+
+def test_stepwise_floor_lookup_within_and_at_boundaries():
+    # a flow lands in the [greatest tabulated discharge <= flow] band
+    assert stepwise_floor_lookup(150, CURVE) == 20
+    assert stepwise_floor_lookup(205, CURVE) == 24
+    # a flow exactly on a tabulated discharge uses that row (<= is inclusive)
+    assert stepwise_floor_lookup(100, CURVE) == 20
+    assert stepwise_floor_lookup(200, CURVE) == 24
+    assert stepwise_floor_lookup(256, CURVE) == 26
+
+
+def test_stepwise_floor_lookup_clamps_below_and_holds_above():
+    # below the lowest tabulated discharge -> clamp to the lowest floor
+    assert stepwise_floor_lookup(0, CURVE) == 20
+    assert stepwise_floor_lookup(60, CURVE) == 20
+    # above the highest tabulated discharge -> hold the highest floor
+    assert stepwise_floor_lookup(300, CURVE) == 26
+
+
+def test_stepwise_floor_lookup_sorts_unordered_curve():
+    unordered = [[256, 26], [100, 20], [200, 24]]
+    assert stepwise_floor_lookup(205, unordered) == 24
+    assert stepwise_floor_lookup(50, unordered) == 20
+
+
+def test_create_flow_wse_envelopes_sweeps_each_flow_from_its_floor():
+    ds_flows = pd.Series([150, 205])
+    depths, flows, wses = create_flow_wse_envelopes(
+        ds_flows,
+        min_elevation_curve=CURVE,
+        max_elevation=30,
+        depth_increment=2,
+        thalweg=10,
+    )
+
+    # flow 150 -> floor 20, swept 20..30; flow 205 -> floor 24, swept 24..30
+    assert wses == [20, 22, 24, 26, 28, 30, 24, 26, 28, 30]
+    assert flows == [150] * 6 + [205] * 4
+    # depth is wse - thalweg
+    assert depths == [10, 12, 14, 16, 18, 20, 14, 16, 18, 20]
+    # parallel lists stay aligned
+    assert len(depths) == len(flows) == len(wses)
+
+
+def test_create_flow_wse_envelopes_keeps_all_flows_on_one_absolute_grid():
+    # The grid is absolute multiples of depth_increment (whole feet for Δz=1), so two
+    # flows with unrelated floors still share one lattice. Each flow's floor is rounded
+    # to the nearest grid line: 21.5 rounds up to 22, not onto a private half-foot phase.
+    ds_flows = pd.Series([150, 250])
+    _, flows, wses = create_flow_wse_envelopes(
+        ds_flows,
+        min_elevation_curve=[[100, 20.0], [200, 21.5]],
+        max_elevation=24,
+        depth_increment=1,
+        thalweg=0,
+    )
+
+    # every wse lands on the same absolute lattice (whole feet) -> not fragmented
+    assert len({round(w % 1, 6) for w in wses}) == 1
+    assert min(w for f, w in zip(flows, wses) if f == 250) == 22.0
+    assert wses == [20, 21, 22, 23, 24, 22, 23, 24]
+
+
+def test_create_flow_wse_envelopes_rounds_bounds_to_nearest_grid_line():
+    # floor 20.3 -> nearest grid line 20; floor 20.6 -> nearest grid line 21 (round half up)
+    ds_flows = pd.Series([150, 250])
+    _, flows, wses = create_flow_wse_envelopes(
+        ds_flows,
+        min_elevation_curve=[[100, 20.3], [200, 20.6]],
+        max_elevation=25,
+        depth_increment=1,
+        thalweg=0,
+    )
+    first = {}
+    for f, w in zip(flows, wses):
+        first.setdefault(f, w)
+    assert first[150] == 20.0
+    assert first[250] == 21.0
+
+
+def test_create_flow_wse_envelopes_matches_worked_example():
+    # d/s WSEL range 224.2 (floor) -> 227.1 (ceiling), swept at each allowed increment.
+    ds_flows = pd.Series([150])
+
+    def rungs(inc):
+        _, _, wses = create_flow_wse_envelopes(
+            ds_flows, min_elevation_curve=[[100, 224.2]], max_elevation=227.1, depth_increment=inc, thalweg=0
+        )
+        return [round(w, 1) for w in wses]
+
+    assert rungs(0.5) == [224.0, 224.5, 225.0, 225.5, 226.0, 226.5, 227.0]
+    assert rungs(1) == [224.0, 225.0, 226.0, 227.0]
+    assert rungs(2) == [224.0, 226.0, 228.0]
+
+
+def test_create_flow_wse_envelopes_grid_is_multiples_of_increment():
+    ds_flows = pd.Series([150, 205, 300])
+    for inc in ALLOWED_DEPTH_INCREMENTS:
+        _, _, wses = create_flow_wse_envelopes(
+            ds_flows, min_elevation_curve=CURVE, max_elevation=60, depth_increment=inc, thalweg=0
+        )
+        assert wses, f"expected rungs for increment {inc}"
+        assert all(abs(w / inc - round(w / inc)) < 1e-6 for w in wses)
+
+
+def test_create_flow_wse_envelopes_single_rung_when_floor_equals_ceiling():
+    # when a flow's floor rounds to the same grid line as the ceiling, it yields one rung
+    ds_flows = pd.Series([150])
+    _, _, wses = create_flow_wse_envelopes(
+        ds_flows, min_elevation_curve=[[100, 26.0]], max_elevation=26.0, depth_increment=1, thalweg=0
+    )
+    assert wses == [26.0]
+
+
+def test_create_flow_wse_envelopes_rejects_disallowed_increment():
+    ds_flows = pd.Series([150])
+    with pytest.raises(ValueError, match="depth_increment must be one of"):
+        create_flow_wse_envelopes(
+            ds_flows, min_elevation_curve=CURVE, max_elevation=30, depth_increment=0.25, thalweg=0
+        )
+
+
+def test_create_flow_wse_envelopes_clamps_flow_to_min_flow():
+    # a flow below MIN_FLOW is clamped up to MIN_FLOW in the emitted profiles
+    ds_flows = pd.Series([0])
+    _, flows, _ = create_flow_wse_envelopes(
+        ds_flows,
+        min_elevation_curve=CURVE,
+        max_elevation=22,
+        depth_increment=2,
+        thalweg=0,
+    )
+    assert set(flows) == {MIN_FLOW}


### PR DESCRIPTION
AI is used for most of the changes in this PR and following description.


Also see relevant PRs:
https://github.com/NGWPC/ripple1d-pipeline/pull/17
https://github.com/NGWPC/twod-fim-knowledge-base/pull/112

2D SDR DR-032 and DR-033 have figures and concept for new approach.
```

Until now the known-water-surface-elevation (KWSE) run took a single scalar
min_elevation and swept one shared ladder of downstream water-surface
elevations for the whole reach, keeping only the rungs whose depth exceeded a
given discharge's own normal-depth result. That had two consequences we no
longer want. Because the floor was tied to a discharge's own normal depth
rather than to the water surface the downstream reach actually presents, the
lowest rung frequently sat above the real tailwater and left the bottom of the
library uncovered, while the highest discharges collapsed toward the ceiling
and produced one- or two-rung "curves" with nothing to interpolate between.
And because the single starting elevation was snapped to the nearest half foot
and then stepped by the increment, each reach inherited whatever half-foot
phase its data happened to fall on, so a library built with a one-foot
increment could still land on a half-foot grid.

This change reconditions the floor on the downstream reach and puts the whole
library on a predictable grid. run_known_wse now accepts a min_elevation_curve,
a list of [discharge, wse] pairs taken from the downstream reach's water
surface, in place of the scalar min_elevation, and a new stepwise_floor_lookup
resolves each discharge to the water surface of the greatest tabulated
discharge at or below it, clamping below the lowest tabulated discharge and
holding at the highest. The replacement create_flow_wse_envelopes sweeps every
discharge from its own floor up to the shared ceiling, so the floor now
reflects the actual tailwater the reach will see rather than the reach's own
normal depth.

The grid itself is now absolute. Rungs are multiples of the stage increment
anchored at zero, so a one-foot increment yields whole feet, a half-foot
increment yields half feet, and a two-foot increment yields even feet,
independent of where any particular tailwater falls. Both the shared ceiling
and each discharge's floor are rounded to the nearest grid line, which keeps
every discharge on one common lattice and accepts at most half an increment of
tolerance at the edges rather than fabricating downstream elevations the reach
can never physically reach; where a discharge's floor rounds onto the ceiling,
that single rung is the honest answer. To keep the grid on clean one-decimal
values the stage increment is restricted to one of {0.5, 1, 2, 5, 10} and is
validated both at the run_known_wse entry point and inside the envelope
builder. The function's return value now reports the water-surface elevations
that were actually run instead of the pre-filtered ladder.

The supporting changes move with the new signature: the API tests, the
rounding-error test, and the Postman collection now send min_elevation_curve;
the FAQ documents how the per-discharge floor is derived; and a new
tests/test_flow_wse_envelopes.py covers the floor lookup, the absolute-grid
placement, the nearest-line rounding, the single-rung floor-meets-ceiling case,
and the increment restriction. The package version is bumped to 0.11.0.
```